### PR TITLE
WIP: use select() in threaded client

### DIFF
--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -23,7 +23,7 @@ from ._commands import (AccessRightsResponse, CreateChFailResponse,
                         read_from_bytestream,)
 from ._state import (ChannelState, CircuitState, get_exception)
 from ._utils import (CLIENT, SERVER, NEED_DATA, DISCONNECTED, CaprotoKeyError,
-                     CaprotoValueError, CaprotoRuntimeError,
+                     CaprotoValueError, CaprotoRuntimeError, CaprotoError,
                      )
 from ._dbr import (SubscriptionType, )
 from ._constants import (DEFAULT_PROTOCOL_VERSION, MAX_ID)
@@ -411,7 +411,12 @@ class _BaseChannel:
         transitions = []
         for role in (self.circuit.our_role, self.circuit.their_role):
             initial_state = self.states[role]
-            self.states.process_command_type(role, type(command))
+            try:
+                self.states.process_command_type(role, type(command))
+            except CaprotoError as ex:
+                ex.channel = self
+                raise
+
             new_state = self.states[role]
             # Assemble arguments needed by state_changed, to be called later.
             if initial_state is not new_state:

--- a/caproto/asyncio/repeater.py
+++ b/caproto/asyncio/repeater.py
@@ -35,7 +35,6 @@ class RepeaterAlreadyRunning(RuntimeError):
 class ProxyDatagramProtocol(asyncio.DatagramProtocol):
 
     def __init__(self):
-        self.host = socket.gethostbyname(socket.gethostname())
         self.remotes = {}
 
         self.broadcaster = caproto.Broadcaster(our_role=caproto.SERVER)

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -160,6 +160,8 @@ class CurioVirtualCircuit:
 
         if command is ca.DISCONNECTED:
             raise DisconnectedCircuit()
+        elif isinstance(command, ca.VersionRequest):
+            return [ca.VersionResponse(13)]
         elif isinstance(command, ca.CreateChanRequest):
             db_entry = self.context.pvdb[command.name.decode(SERVER_ENCODING)]
             access = db_entry.check_access(self.client_hostname,

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1499,7 +1499,7 @@ def cainfo(pvname, print_out=True):
         thispv.get()
         thispv.get_ctrlvars()
         if print_out:
-            ca.write(thispv.info)
+            print(thispv.info)
         else:
             return thispv.info
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -7,6 +7,7 @@ import socket
 import threading
 import time
 import weakref
+import selectors
 
 from collections import Iterable
 
@@ -44,49 +45,90 @@ def _condition_with_timeout(bail_condition: Callable[[], bool],
                 raise TimeoutError()
 
 
-class SocketThread:
-    def __init__(self, socket, target_obj):
-        self.socket = socket
-        if socket.timeout is None:
-            socket.settimeout(.1)
-        self.target_obj = weakref.ref(target_obj)
+class SelectorThread:
+    def __init__(self):
+        self._running = False
+        self.selector = selectors.DefaultSelector()
+        self.object_to_socket = {}
+        self.socket_to_object = {}
         self.thread = threading.Thread(target=self, daemon=True)
+
+    @property
+    def running(self):
+        '''Selector thread is running'''
+        return self._running
+
+    def stop(self):
+        self._running = False
+
+    def start(self):
+        self._running = True
         self.thread.start()
-        self.poison_ev = threading.Event()
+
+    def add_socket(self, socket, target_obj):
+        socket.setblocking(False)
+        ref = target_obj  # weakref.proxy(target_obj, self._object_removed)
+        close_event = threading.Event()
+
+        self.object_to_socket[ref] = (socket, close_event)
+        self.socket_to_object[socket] = (ref, close_event)
+        self.selector.register(socket, selectors.EVENT_READ)
+        return close_event
+
+    def remove_socket(self, socket):
+        obj, close_event = self.socket_to_object.pop(socket)
+        del self.object_to_socket[obj]
+        self.selector.unregister(socket)
+        if not close_event.isSet():
+            close_event.set()
+        if not self.socket_to_object:
+            self.stop()
+
+    def _object_removed(self, ref):
+        socket, close_event = self.object_to_socket.pop(ref)
+        del self.socket_to_object[socket]
+        self.selector.unregister(socket)
+        if not close_event.isSet():
+            close_event.set()
 
     def __call__(self):
-        num_bytes_needed = 0
-        while True:
-            if num_bytes_needed is None:
-                print(self.target_obj())
-            try:
-                bytes_recv, address = self.socket.recvfrom(
-                    max(4096, num_bytes_needed))
-            except socket.timeout:
-                if self.poison_ev.isSet():
+        '''Selector poll loop'''
+        while self._running:
+            events = self.selector.select(timeout=0.5)
+            for key, mask in events:
+                sock = key.fileobj
+                obj, close_ev = self.socket_to_object[sock]
+                # TODO: consider thread pool for recv and command_loop
+                try:
+                    bytes_recv, address = sock.recvfrom(4096)
+                except OSError:
                     bytes_recv, address = b'', None
+
+                try:
+                    recv_method = obj.received
+                except ReferenceError:
+                    self._object_removed(obj)
+                    return
                 else:
-                    continue
-            except OSError:
-                bytes_recv, address = b'', None
+                    recv_method(bytes_recv, address)
 
-            target = self.target_obj()
-            if target is None:
-                break
 
-            num_bytes_needed = target.received(bytes_recv, address)
-            if not len(bytes_recv):
-                target.disconnect()
-                # this is important to not keep a hard-ref to the target
-                target = None
-                return
+_selector = None
+
+def get_selector():
+    '''Shared Selector thread between all clients'''
+    global _selector
+    if _selector is None:
+        _selector = SelectorThread()
+    if not _selector.running:
+        _selector.start()
+    return _selector
 
 
 class SharedBroadcaster:
     def __init__(self, *, log_level='ERROR'):
         self.log_level = log_level
         self.udp_sock = None
-        self.sock_thread = None
         self._search_lock = threading.RLock()
 
         self.search_results = {}  # map name to (time, address)
@@ -105,7 +147,8 @@ class SharedBroadcaster:
     def __create_sock(self):
         # UDP socket broadcasting to CA servers
         self.udp_sock = ca.bcast_socket()
-        self.sock_thread = SocketThread(self.udp_sock, self)
+        selector = get_selector()
+        selector.add_socket(self.udp_sock, self)
 
     def add_listener(self, listener):
         self.listeners.add(listener)
@@ -124,27 +167,21 @@ class SharedBroadcaster:
             self.disconnect()
 
     def disconnect(self, *, wait=True):
-        th = []
-
         if self.udp_sock is not None:
-            self.sock_thread.poison_ev.set()
-            self.udp_sock.close()
-            th.append(self.sock_thread.thread)
+            _selector.remove_socket(self.udp_sock)
 
         with self._search_lock:
             self.search_results.clear()
         self.udp_sock = None
         self.broadcaster.disconnect()
 
-        if wait:
-            cur_thread = threading.current_thread()
-            for t in th:
-                if t is not cur_thread:
-                    t.join()
+        # if wait and self.command_thread is not threading.current_thread():
+        #     self.command_thread.join()
+        # TODO: no close_event integration
 
     def send(self, port, *commands):
         """
-        Process a command and tranport it over the UDP socket.
+        Process a command and transport it over the UDP socket.
         """
         with self.command_cond:
             bytes_to_send = self.broadcaster.send(*commands)
@@ -330,24 +367,13 @@ class Context:
         return chan
 
     def disconnect(self):
-        th = []
-
         # disconnect any circuits we have
         for circ in list(self.circuits.values()):
             if circ.connected:
-                st = circ.sock_thread
-                if st is not None:
-                    th.append(st.thread)
                 circ.disconnect()
 
         # clear any state about circuits and search results
         self.circuits.clear()
-
-        cur_thread = threading.current_thread()
-        # wait for all of the socket threads to stop
-        for t in th:
-            if t is not cur_thread:
-                t.join()
 
         # disconnect the underlying state machine
         self.broadcaster.remove_listener(self)
@@ -363,8 +389,8 @@ class Context:
 
 class VirtualCircuit:
     __slots__ = ('circuit', 'channels', 'ioids', 'subscriptionids',
-                 'new_command_cond', 'socket', 'sock_thread',
-                 'command_thread', 'command_queue',
+                 'new_command_cond', 'socket', 'command_thread',
+                 'command_queue',
                  '__weakref__')
 
     def __init__(self, circuit):
@@ -374,7 +400,6 @@ class VirtualCircuit:
         self.subscriptionids = {}  # map subscriptionid to Channel
         self.new_command_cond = threading.Condition()  # ConditionType
         self.socket = None
-        self.sock_thread = None
         self.command_queue = queue.Queue()
         self.command_thread = threading.Thread(target=self.command_thread_loop,
                                                daemon=True)
@@ -385,10 +410,12 @@ class VirtualCircuit:
             return self.circuit.states[ca.CLIENT] is ca.CONNECTED
 
     def create_connection(self):
-        if self.sock_thread is not None:
-            raise RuntimeError('trying to reuse a VC')
+        # TODO check removed
+        # if self.sock_thread is not None:
+        #     raise RuntimeError('trying to reuse a VC')
         self.socket = socket.create_connection(self.circuit.address)
-        self.sock_thread = SocketThread(self.socket, self)
+        selector = get_selector()
+        selector.add_socket(self.socket, self)
 
     def send(self, *commands):
         with self.new_command_cond:
@@ -440,23 +467,14 @@ class VirtualCircuit:
 
         with self.new_command_cond:
             self.circuit.disconnect()
-        threads = []
-        if self.sock_thread is not None:
-            th = self.sock_thread.thread
-            self.sock_thread.poison_ev.set()
-            threads.append(th)
-        if self.command_thread is not None:
-            threads.append(self.command_thread)
-        if wait:
-            cur_thread = threading.current_thread()
-            for th in threads:
-                if th is not cur_thread:
-                    th.join()
+        if self.socket is not None:
+            _selector.remove_socket(self.socket)
+        if wait and self.command_thread is not threading.current_thread():
+            self.command_thread.join()
 
         self.channels.clear()
         self.ioids.clear()
         self.socket = None
-        self.sock_thread = None
 
     def __del__(self):
         try:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -10,6 +10,7 @@ import weakref
 import selectors
 import array
 import fcntl
+import errno
 import termios
 import struct
 import inspect
@@ -155,7 +156,10 @@ class SelectorThread:
                         raise OSError('ioctl failed')
                     bytes_available = struct.unpack('I', avail_buf)[0]
                     bytes_recv, address = sock.recvfrom(bytes_available)
-                except OSError:
+                except OSError as ex:
+                    if ex.errno == errno.EAGAIN and bytes_available == 0:
+                        continue
+
                     bytes_recv, address = b'', None
 
                 try:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -142,33 +142,32 @@ class SelectorThread:
                 self._register_sockets.clear()
 
             events = self.selector.select(timeout=0.1)
-            for key, mask in events:
-                sock = key.fileobj
-                try:
-                    obj_id = self.socket_to_id[sock]
-                except KeyError:
+            with self._socket_map_lock:
+                if self._unregister_sockets or self._register_sockets:
                     continue
 
+                ready_ids = [self.socket_to_id[key.fileobj]
+                             for key, mask in events]
+                ready_objs = [(self.objects[obj_id], self.id_to_socket[obj_id])
+                              for obj_id in ready_ids]
+
+            for obj, sock in ready_objs:
                 # TODO: consider thread pool for recv and command_loop
 
-                try:
-                    if fcntl.ioctl(sock, termios.FIONREAD, avail_buf) < 0:
-                        raise OSError('ioctl failed')
-                    bytes_available = struct.unpack('I', avail_buf)[0]
-                    bytes_recv, address = sock.recvfrom(bytes_available)
-                except OSError as ex:
-                    if ex.errno == errno.EAGAIN and bytes_available == 0:
-                        continue
+                if fcntl.ioctl(sock, termios.FIONREAD, avail_buf) < 0:
+                    continue
 
+                bytes_available = avail_buf[0]
+
+                try:
+                    bytes_recv, address = sock.recvfrom(max((4096,
+                                                             bytes_available)))
+                except OSError as ex:
+                    if ex.errno == errno.EAGAIN:
+                        continue
                     bytes_recv, address = b'', None
 
-                try:
-                    obj = self.objects[obj_id]
-                except KeyError:
-                    self._object_removed(obj_id)
-                    return
-                else:
-                    obj.received(bytes_recv, address)
+                obj.received(bytes_recv, address)
 
 
 class SharedBroadcaster:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -12,12 +12,21 @@ import array
 import fcntl
 import termios
 import struct
+import inspect
 
 from collections import Iterable
 
 import caproto as ca
 
 from typing import Callable, Optional
+
+
+class ThreadingClientException(Exception):
+    ...
+
+
+class DisconnectedError(ThreadingClientException):
+    ...
 
 
 class ConditionType:
@@ -53,9 +62,15 @@ class SelectorThread:
     def __init__(self):
         self._running = False
         self.selector = selectors.DefaultSelector()
+
         self._socket_map_lock = threading.RLock()
-        self.object_to_socket = {}
-        self.socket_to_object = {}
+        self.objects = weakref.WeakValueDictionary()
+        self.id_to_socket = {}
+        self.socket_to_id = {}
+
+        self._register_sockets = []
+        self._unregister_sockets = []
+        self._object_id = 0
 
     @property
     def running(self):
@@ -74,44 +89,65 @@ class SelectorThread:
         self.thread.start()
 
     def add_socket(self, socket, target_obj):
-        socket.setblocking(False)
-        ref = target_obj  # weakref.proxy(target_obj, self._object_removed)
-        close_event = threading.Event()
-
         with self._socket_map_lock:
-            self.object_to_socket[ref] = (socket, close_event)
-            self.socket_to_object[socket] = (ref, close_event)
-            self.selector.register(socket, selectors.EVENT_READ)
-        return close_event
+            if socket in self.socket_to_id:
+                raise ValueError('Socket already added')
 
-    def remove_socket(self, socket):
+            socket.setblocking(False)
+
+            # assumption: only one socket per object
+            self._object_id += 1
+            self.objects[self._object_id] = target_obj
+            self.id_to_socket[self._object_id] = socket
+            self.socket_to_id[socket] = self._object_id
+            weakref.finalize(target_obj,
+                             lambda obj_id=self._object_id:
+                             self._object_removed(obj_id))
+            self._register_sockets.append(socket)
+
+    def remove_socket(self, sock):
         with self._socket_map_lock:
-            obj, close_event = self.socket_to_object.pop(socket)
-            del self.object_to_socket[obj]
-            obj.received(b'', None)
-            self.selector.unregister(socket)
+            if sock not in self.socket_to_id:
+                return
 
-        if not close_event.isSet():
-            close_event.set()
-        if not self.socket_to_object:
+            obj_id = self.socket_to_id.pop(sock)
+            del self.id_to_socket[obj_id]
+            obj = self.objects.pop(obj_id, None)
+            if obj is not None:
+                obj.received(b'', None)
+            self._unregister_sockets.append(sock)
+
+        if not self.socket_to_id:
             self.stop()
 
-    def _object_removed(self, ref):
+    def _object_removed(self, obj_id):
         with self._socket_map_lock:
-            socket, close_event = self.object_to_socket.pop(ref)
-            del self.socket_to_object[socket]
-            self.selector.unregister(socket)
-        if not close_event.isSet():
-            close_event.set()
+            if obj_id in self.id_to_socket:
+                sock = self.id_to_socket.pop(obj_id)
+                del self.socket_to_id[sock]
+                self._unregister_sockets.append(sock)
 
     def __call__(self):
         '''Selector poll loop'''
         avail_buf = array.array('i', [0])
         while self._running:
-            events = self.selector.select(timeout=0.2)
+            with self._socket_map_lock:
+                for sock in self._unregister_sockets:
+                    self.selector.unregister(sock)
+                self._unregister_sockets.clear()
+
+                for sock in self._register_sockets:
+                    self.selector.register(sock, selectors.EVENT_READ)
+                self._register_sockets.clear()
+
+            events = self.selector.select(timeout=0.1)
             for key, mask in events:
                 sock = key.fileobj
-                obj, close_ev = self.socket_to_object[sock]
+                try:
+                    obj_id = self.socket_to_id[sock]
+                except KeyError:
+                    continue
+
                 # TODO: consider thread pool for recv and command_loop
 
                 try:
@@ -123,24 +159,12 @@ class SelectorThread:
                     bytes_recv, address = b'', None
 
                 try:
-                    recv_method = obj.received
-                except ReferenceError:
-                    self._object_removed(obj)
+                    obj = self.objects[obj_id]
+                except KeyError:
+                    self._object_removed(obj_id)
                     return
                 else:
-                    recv_method(bytes_recv, address)
-
-
-_selector = None
-
-def get_selector():
-    '''Shared Selector thread between all clients'''
-    global _selector
-    if _selector is None:
-        _selector = SelectorThread()
-    if not _selector.running:
-        _selector.start()
-    return _selector
+                    obj.received(bytes_recv, address)
 
 
 class SharedBroadcaster:
@@ -158,15 +182,19 @@ class SharedBroadcaster:
         self.broadcaster.log.setLevel(self.log_level)
         self.command_bundle_queue = queue.Queue()
         self.command_cond = threading.Condition()  # ConditionType
+
+        self.selector = SelectorThread()
         self.command_thread = threading.Thread(target=self.command_loop,
                                                daemon=True)
         self.command_thread.start()
 
     def __create_sock(self):
         # UDP socket broadcasting to CA servers
+        if self.udp_sock is not None:
+            self.selector.remove_socket(self.udp_sock)
+        self.selector.start()
         self.udp_sock = ca.bcast_socket()
-        selector = get_selector()
-        selector.add_socket(self.udp_sock, self)
+        self.selector.add_socket(self.udp_sock, self)
 
     def add_listener(self, listener):
         self.listeners.add(listener)
@@ -184,9 +212,9 @@ class SharedBroadcaster:
         if not self.listeners:
             self.disconnect()
 
-    def disconnect(self, *, wait=True):
+    def disconnect(self, *, wait=True, timeout=2):
         if self.udp_sock is not None:
-            _selector.remove_socket(self.udp_sock)
+            self.selector.remove_socket(self.udp_sock)
 
         with self._search_lock:
             self.search_results.clear()
@@ -195,7 +223,6 @@ class SharedBroadcaster:
 
         # if wait and self.command_thread is not threading.current_thread():
         #     self.command_thread.join()
-        # TODO: no close_event integration
 
     def send(self, port, *commands):
         """
@@ -317,7 +344,8 @@ class SharedBroadcaster:
 
 class Context:
     "Wraps a Broadcaster, and cache of VirtualCircuits."
-    __slots__ = ('broadcaster', 'circuits', 'log_level', '__weakref__')
+    __slots__ = ('broadcaster', 'circuits', 'log_level', 'selector',
+                 '__weakref__')
 
     def __init__(self, broadcaster, *, log_level='ERROR'):
         self.log_level = log_level
@@ -326,6 +354,7 @@ class Context:
         self.broadcaster.add_listener(self)
 
         self.circuits = {}  # map (address, priority) to VirtualCircuit
+        self.selector = None
 
     def register(self):
         "Register this client with the CA Repeater."
@@ -341,12 +370,18 @@ class Context:
 
         Make a new one if necessary.
         """
+        if self.selector is None:
+            self.selector = SelectorThread()
+
+        self.selector.start()
+
         circuit = self.circuits.get((address, priority), None)
         if circuit is None or not circuit.connected:
             circuit = VirtualCircuit(ca.VirtualCircuit(our_role=ca.CLIENT,
                                                        address=address,
                                                        priority=priority,
-                                                       ))
+                                                       ),
+                                     selector=self.selector)
             circuit.circuit.log.setLevel(self.log_level)
             self.circuits[(address, priority)] = circuit
         return circuit
@@ -384,22 +419,23 @@ class Context:
 
         return chan
 
-    def disconnect(self):
-        # disconnect any circuits we have
-        for circ in list(self.circuits.values()):
-            if circ.connected:
-                circ.disconnect()
+    def disconnect(self, *, wait=True, timeout=2):
+        try:
+            # disconnect any circuits we have
+            for circ in list(self.circuits.values()):
+                if circ.connected:
+                    circ.disconnect(wait=wait, timeout=timeout)
+        finally:
+            # clear any state about circuits and search results
+            self.circuits.clear()
 
-        # clear any state about circuits and search results
-        self.circuits.clear()
-
-        # disconnect the underlying state machine
-        self.broadcaster.remove_listener(self)
+            # disconnect the underlying state machine
+            self.broadcaster.remove_listener(self)
 
     def __del__(self):
         try:
-            self.disconnect()
-        except AttributeError:
+            self.disconnect(wait=False)
+        except (KeyError, AttributeError):
             pass
             # clean-up on deletion is best effort...
             # TODO tacaswell
@@ -408,10 +444,10 @@ class Context:
 class VirtualCircuit:
     __slots__ = ('circuit', 'channels', 'ioids', 'subscriptionids',
                  'new_command_cond', 'socket', 'command_thread',
-                 'command_queue',
+                 'command_queue', 'selector',
                  '__weakref__')
 
-    def __init__(self, circuit):
+    def __init__(self, circuit, selector):
         self.circuit = circuit  # a caproto.VirtualCircuit
         self.channels = {}  # map cid to Channel
         self.ioids = {}  # map ioid to Channel
@@ -421,6 +457,7 @@ class VirtualCircuit:
         self.command_queue = queue.Queue()
         self.command_thread = threading.Thread(target=self.command_thread_loop,
                                                daemon=True)
+        self.selector = selector
 
     @property
     def connected(self):
@@ -432,8 +469,7 @@ class VirtualCircuit:
         # if self.sock_thread is not None:
         #     raise RuntimeError('trying to reuse a VC')
         self.socket = socket.create_connection(self.circuit.address)
-        selector = get_selector()
-        selector.add_socket(self.socket, self)
+        self.selector.add_socket(self.socket, self)
 
     def send(self, *commands):
         with self.new_command_cond:
@@ -478,15 +514,15 @@ class VirtualCircuit:
 
                 self.new_command_cond.notify_all()
 
-    def disconnect(self, *, wait=True):
+    def disconnect(self, *, wait=True, timeout=2.0):
         for cid, ch in list(self.channels.items()):
-            ch.disconnect()
+            ch.disconnect(wait=wait, timeout=timeout)
             self.channels.pop(cid)
 
         with self.new_command_cond:
             self.circuit.disconnect()
         if self.socket is not None:
-            _selector.remove_socket(self.socket)
+            self.selector.remove_socket(self.socket)
             try:
                 self.socket.shutdown(socket.SHUT_WR)
                 self.socket.close()
@@ -535,14 +571,22 @@ class Channel:
         needs to do CPU-intensive or I/O-related work, it should execute that
         work in a separate thread of process.
         """
-        self._callback = func
+        if inspect.ismethod(func):
+            self._callback = weakref.WeakMethod(func, self._callback_cleared)
+        else:
+            self._callback = weakref.ref(func, self._callback_cleared)
+
+    def _callback_cleared(self, ref):
+        self._callback = None
 
     def process_subscription(self, event_add_command):
         if self._callback is None:
             return
-        else:
+
+        user_callback = self._callback()
+        if user_callback is not None:
             try:
-                return self._callback(event_add_command)
+                user_callback(event_add_command)
             except Exception as ex:
                 print(ex)
 
@@ -617,9 +661,13 @@ class Channel:
         self.circuit.ioids[ioid] = self
         # do not need lock here, happens in send
         self.circuit.send(command)
-        _condition_with_timeout(lambda: ioid not in self.circuit.ioids,
+        _condition_with_timeout(lambda: ((ioid not in self.circuit.ioids) or
+                                         not self.connected),
                                 self.circuit.new_command_cond,
                                 timeout)
+        if not self.connected:
+            raise DisconnectedError('disconnected during read request')
+
         return self.last_reading
 
     def write(self, *args, wait=True, cb=None, timeout=2, **kwargs):
@@ -634,10 +682,12 @@ class Channel:
         # do not need to lock this, locking happens in circuit command
         self.circuit.send(command)
         if wait:
-            _condition_with_timeout(lambda: ioid not in self.circuit.ioids,
+            _condition_with_timeout(lambda: ((ioid not in self.circuit.ioids) or
+                                             not self.connected),
                                     self.circuit.new_command_cond,
                                     timeout)
-        return self.last_reading
+            if not self.connected:
+                raise DisconnectedError('disconnected during write request')
 
     def subscribe(self, *args, **kwargs):
         "Start a new subscription and spawn an async task to receive readings."
@@ -955,7 +1005,7 @@ class PV:
     def get_ctrlvars(self, timeout=5, warn=True):
         "get control values for variable"
         dtype = ca.promote_type(self.type, use_ctrl=True)
-        command = self.chid.read(data_type=dtype)
+        command = self.chid.read(data_type=dtype, timeout=timeout)
         info = self._parse_dbr_metadata(command.metadata)
         info['value'] = command.data
         self._args.update(**info)
@@ -965,7 +1015,7 @@ class PV:
     def get_timevars(self, timeout=5, warn=True):
         "get time values for variable"
         dtype = ca.promote_type(self.type, use_time=True)
-        command = self.chid.read(data_type=dtype)
+        command = self.chid.read(data_type=dtype, timeout=timeout)
         info = self._parse_dbr_metadata(command.metadata)
         info['value'] = command.data
         self._args.update(**info)
@@ -1321,7 +1371,7 @@ class PV:
         "wrapper for property retrieval"
         if self._args['value'] is None:
             self.get()
-        if self._args[arg] is None:
+        if self._args[arg] is None and self.connected:
             if arg in ('status', 'severity', 'timestamp',
                        'posixseconds', 'nanoseconds'):
                 self.get_timevars(timeout=1, warn=False)
@@ -1350,7 +1400,8 @@ class PV:
             self.chid.disconnect()
 
     def __del__(self):
-        self.disconnect()
+        if self.connected:
+            self.chid.disconnect(wait=False)
 
 
 _dflt_context = None

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -684,7 +684,7 @@ class Channel:
                                          not self.connected),
                                 self.circuit.new_command_cond,
                                 timeout)
-        if not self.connected:
+        if ioid in self.circuit.ioids and not self.connected:
             raise DisconnectedError('disconnected during read request')
 
         return self.last_reading
@@ -705,7 +705,7 @@ class Channel:
                                              not self.connected),
                                     self.circuit.new_command_cond,
                                     timeout)
-            if not self.connected:
+            if ioid in self.circuit.ioids and not self.connected:
                 raise DisconnectedError('disconnected during write request')
 
     def subscribe(self, *args, **kwargs):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -149,6 +149,25 @@ class SharedBroadcaster:
         with self.command_cond:
             bytes_to_send = self.broadcaster.send(*commands)
             for host in ca.get_address_list():
+                if ':' in host:
+                    host, _, specified_port = host.partition(':')
+                    is_register = isinstance(commands[0],
+                                             ca.RepeaterRegisterRequest)
+                    if not self.registered and is_register:
+                        logger.debug('Specific IOC host/port designated in '
+                                     'address list: %s:%s.  Repeater '
+                                     'registration requirement ignored', host,
+                                     specified_port)
+                        with self.command_cond:
+                            # TODO how does this work with multiple addresses
+                            # listed?
+                            response = (('127.0.0.1', ca.EPICS_CA1_PORT),
+                                        [ca.RepeaterConfirmResponse(
+                                            repeater_address='127.0.0.1')]
+                                        )
+                            self.broadcaster.command_queue.put(response)
+                            self.command_cond.notify_all()
+                        continue
                 self.udp_sock.sendto(bytes_to_send, (host, port))
 
     def register(self, *, wait=True):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -247,14 +247,17 @@ class SharedBroadcaster:
                         with self.command_cond:
                             # TODO how does this work with multiple addresses
                             # listed?
-                            response = (('127.0.0.1', ca.EPICS_CA1_PORT),
-                                        [ca.RepeaterConfirmResponse(
-                                            repeater_address='127.0.0.1')]
-                                        )
-                            self.broadcaster.command_queue.put(response)
+                            response = ca.RepeaterConfirmResponse(
+                                repeater_address='127.0.0.1')
+                            response.sender_address = ('127.0.0.1',
+                                                       ca.EPICS_CA1_PORT)
+                            self.command_bundle_queue.put([response])
                             self.command_cond.notify_all()
                         continue
-                self.udp_sock.sendto(bytes_to_send, (host, port))
+                    self.udp_sock.sendto(bytes_to_send, (host,
+                                                         int(specified_port)))
+                else:
+                    self.udp_sock.sendto(bytes_to_send, (host, port))
 
     def register(self, *, wait=True):
         "Register this client with the CA Repeater."
@@ -501,7 +504,8 @@ class VirtualCircuit:
                 if hasattr(ex, 'channel'):
                     channel = ex.channel
                     logger.warning('Invalid command %s for Channel %s in '
-                                   'state %s', command, channel, channel.states,
+                                   'state %s', command, channel,
+                                   channel.states,
                                    exc_info=ex)
                     # channel exceptions are not fatal
                     continue

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -317,7 +317,12 @@ class SharedBroadcaster:
     def command_loop(self):
         while True:
             commands = self.command_bundle_queue.get()
-            self.broadcaster.process_commands(commands)
+            try:
+                self.broadcaster.process_commands(commands)
+            except ca.CaprotoError as ex:
+                logger.warning('Broadcaster command error', exc_info=ex)
+                continue
+
             with self.command_cond:
                 for command in commands:
                     if isinstance(command, ca.VersionResponse):

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default: false
+      tests:
+        target: 0%
+        paths:
+          - "tests/"
+      caproto:
+        target: auto
+        threshold: 1%
+        paths:
+          - "caproto/"
+          - "!caproto/generate_headers.py"
+          - "!caproto/_version.py"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -134,7 +134,6 @@ def test_curio_server():
         await chan1.circuit.socket.close()
 
     async def task():
-        # os.environ['EPICS_CA_ADDR_LIST'] = '255.255.255.255'
         try:
             server_task = await curio.spawn(example_server())
             await curio.sleep(1)  # Give server some time to start up.
@@ -508,3 +507,49 @@ def test_curio_server_with_caget(curio_server, pv, dbr_type):
     with curio.Kernel() as kernel:
         kernel.run(task)
     print('done')
+
+
+def test_curio_server_and_thread_client(curio_server):
+    from caproto.threading.client import (SharedBroadcaster, PV,
+                                          PVContext)
+    from conftest import threaded_in_curio_wrapper
+
+    @threaded_in_curio_wrapper
+    def client_test():
+        shared_broadcaster = SharedBroadcaster()
+        cntx = PVContext(broadcaster=shared_broadcaster, log_level='DEBUG')
+
+        pv = PV('int', context=cntx)
+        assert pv.get() == caget_pvdb['int'].value
+        print('get', pv.get())
+
+        monitor_values = []
+
+        def callback(value=None, **kwargs):
+            print('monitor', value)
+            monitor_values.append(value[0])
+
+        pv.add_callback(callback)
+        pv.put(1, wait=True)
+        pv.put(2, wait=True)
+        pv.put(3, wait=True)
+
+        for i in range(3):
+            if pv.get() == 3:
+                break
+            else:
+                time.sleep(0.1)
+
+        assert len(monitor_values) == 4
+
+    async def task():
+        server_task = await curio.spawn(curio_server)
+
+        try:
+            await curio.run_in_thread(client_test)
+            await client_test.wait()
+        finally:
+            await server_task.cancel()
+
+    with curio.Kernel() as kernel:
+        kernel.run(task)

--- a/tests/test_thread_pv.py
+++ b/tests/test_thread_pv.py
@@ -197,8 +197,10 @@ class PV_Tests(unittest.TestCase):
         write('Simple Test of caget() function\n')
         pvs = (pvnames.double_pv, pvnames.enum_pv, pvnames.str_pv)
         for p in pvs:
-            val = cainfo(p, print_out=False)
-            self.assertIsNot(val, None)
+            for print_out in (True, False):
+                val = cainfo(p, print_out=print_out)
+                if not print_out:
+                    self.assertIsNot(val, None)
 
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')


### PR DESCRIPTION
Reduces number of threads in threaded client drastically. Can be reduced further in the future.

 - [ ] threadpool to handle message parsing
 - [x] fix up weakref failed attempt
 - [x] make the selector per-context and not per-process