### PR TITLE
CLN: Misc cleanup on middle layers in prep for better docs

### DIFF
--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -3,8 +3,8 @@
 # It builds on the abstractions used in caproto, adding transport and some
 # caches for matching requests with responses.
 #
-# VirtualCircuit: has a caproto.VirtualCircuit, a socket, and some caches.
-# Channel: has a VirtualCircuit and a caproto.ClientChannel.
+# CurioVirtualCircuit: has a caproto.VirtualCircuit, a socket, and some caches.
+# CurioChannel: has a CurioVirtualCircuit and a caproto.ClientChannel.
 # Context: has a caproto.Broadcaster, a UDP socket, a cache of
 #          search results and a cache of VirtualCircuits.
 #
@@ -21,14 +21,14 @@ class ChannelReadError(Exception):
     ...
 
 
-class VirtualCircuit:
+class CurioVirtualCircuit:
     "Wraps a caproto.VirtualCircuit and adds transport."
     def __init__(self, circuit):
         self.circuit = circuit  # a caproto.VirtualCircuit
-        self.channels = {}  # map cid to Channel
-        self.ioids = {}  # map ioid to Channel
+        self.channels = {}  # map cid to CurioChannel
+        self.ioids = {}  # map ioid to CurioChannel
         self.ioid_data = {}  # map ioid to server response
-        self.subscriptionids = {}  # map subscriptionid to Channel
+        self.subscriptionids = {}  # map subscriptionid to CurioChannel
         self.connected = True
         self.socket = None
         self.command_queue = curio.Queue()
@@ -97,10 +97,10 @@ class VirtualCircuit:
                 await self.socket.sendmsg(buffers_to_send)
 
 
-class Channel:
-    """Wraps a VirtualCircuit and a caproto.ClientChannel."""
+class CurioChannel:
+    """Wraps a CurioVirtualCircuit and a caproto.ClientChannel."""
     def __init__(self, circuit, channel):
-        self.circuit = circuit  # a VirtualCircuit
+        self.circuit = circuit  # a CurioVirtualCircuit
         self.channel = channel  # a caproto.ClientChannel
         self.last_reading = None
         self.monitoring_tasks = {}  # maps subscriptionid to curio.Task
@@ -322,15 +322,15 @@ class SharedBroadcaster:
 
 
 class Context:
-    "Wraps a caproto.Broadcaster, a UDP socket, and cache of VirtualCircuits."
+    "Wraps a caproto.Broadcaster, a UDP socket, and CurioVirtualCircuits."
     def __init__(self, broadcaster, *, log_level='ERROR'):
         self.log_level = log_level
-        self.circuits = []  # list of VirtualCircuits
+        self.circuits = []  # list of CurioVirtualCircuits
         self.broadcaster = broadcaster
 
     def get_circuit(self, address, priority):
         """
-        Return a VirtualCircuit with this address, priority.
+        Return a CurioVirtualCircuit with this address, priority.
 
         Make a new one if necessary.
         """
@@ -341,7 +341,7 @@ class Context:
 
         ca_circuit = ca.VirtualCircuit(our_role=ca.CLIENT, address=address,
                                        priority=priority)
-        circuit = VirtualCircuit(ca_circuit)
+        circuit = CurioVirtualCircuit(ca_circuit)
         circuit.circuit.log.setLevel(self.log_level)
         self.circuits.append(circuit)
         return circuit
@@ -372,4 +372,4 @@ class Context:
         assert circuit.socket is not None
         # Send command that creates the Channel.
         await circuit.send(chan.create())
-        return Channel(circuit, chan)
+        return CurioChannel(circuit, chan)

--- a/caproto/examples/thread_client_simple.py
+++ b/caproto/examples/thread_client_simple.py
@@ -11,8 +11,6 @@ def main(pv1="XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL",
     '''
 
     shared_broadcaster = SharedBroadcaster()
-    pv1 = "XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL"
-    pv2 = "XF:31IDA-OP{Tbl-Ax:X2}Mtr.VAL"
 
     # Some user function to call when subscriptions receive data.
     called = []

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -244,10 +244,11 @@ class Context:
         """
         circuit = self.circuits.get((address, priority), None)
         if circuit is None or not circuit.connected:
-            circuit = VirtualCircuit(ca.VirtualCircuit(our_role=ca.CLIENT,
-                                                       address=address,
-                                                       priority=priority,
-                                                       ))
+            circuit = ThreadingVirtualCircuit(
+                ca.VirtualCircuit(our_role=ca.CLIENT,
+                                  address=address,
+                                  priority=priority,
+                                 ))
             circuit.circuit.log.setLevel(self.log_level)
             self.circuits[(address, priority)] = circuit
         return circuit
@@ -261,7 +262,7 @@ class Context:
         circuit = self.get_circuit(address, priority)
         cid = circuit.circuit.new_channel_id()
         cachan = ca.ClientChannel(name, circuit.circuit, cid=cid)
-        chan = circuit.channels[cid] = Channel(circuit, cachan)
+        chan = circuit.channels[cid] = ThreadingChannel(circuit, cachan)
 
         with circuit.new_command_cond:
             if circuit.circuit.states[ca.SERVER] is ca.IDLE:
@@ -321,7 +322,7 @@ class Context:
             # TODO tacaswell
 
 
-class VirtualCircuit:
+class ThreadingVirtualCircuit:
     __slots__ = ('circuit', 'channels', 'ioids', 'subscriptionids',
                  'new_command_cond', 'socket', 'sock_thread',
                  'command_thread', 'command_queue',
@@ -329,9 +330,9 @@ class VirtualCircuit:
 
     def __init__(self, circuit):
         self.circuit = circuit  # a caproto.VirtualCircuit
-        self.channels = {}  # map cid to Channel
-        self.ioids = {}  # map ioid to Channel
-        self.subscriptionids = {}  # map subscriptionid to Channel
+        self.channels = {}  # map cid to ThreadingChannel
+        self.ioids = {}  # map ioid to ThreadingChannel
+        self.subscriptionids = {}  # map subscriptionid to ThreadingChannel
         self.new_command_cond = threading.Condition()  # ConditionType
         self.socket = None
         self.sock_thread = None
@@ -425,14 +426,14 @@ class VirtualCircuit:
             pass
 
 
-class Channel:
-    """Wraps a VirtualCircuit and a caproto.ClientChannel."""
+class ThreadingChannel:
+    """Wraps a ThreadingVirtualCircuit and a caproto.ClientChannel."""
     __slots__ = ('circuit', 'channel', 'last_reading', 'monitoring_tasks',
                  '_callback', '_read_notify_callback', 'command_bundle_queue',
                  '_write_notify_callback', '_pc_callbacks')
 
     def __init__(self, circuit, channel):
-        self.circuit = circuit  # a VirtualCircuit
+        self.circuit = circuit  # a ThreadingVirtualCircuit
         self.channel = channel  # a caproto.ClientChannel
         self.last_reading = None
         self.monitoring_tasks = {}  # maps subscriptionid to curio.Task

--- a/tests/test_threading_client.py
+++ b/tests/test_threading_client.py
@@ -1,10 +1,6 @@
 import sys
 import socket
 import logging
-import time
-import threading
-
-from multiprocessing import Process
 
 from caproto.threading.client import (SocketThread, Context, SharedBroadcaster)
 import caproto as ca


### PR DESCRIPTION
- Consistently follow pattern of naming things CurioVirtualCircuit etc.
- Move all testing code to tests, not in __main__ of modules. (Some tests were
  being maintained redundantly in both places; some needed to be moved.)