### PR TITLE
Refactor of ChannelData server utilities

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -210,6 +210,7 @@ class ChannelData:
         self.string_encoding = string_encoding
         self.reported_record_type = reported_record_type
         self._subscription_queue = None
+        # a dict of un-filled structs for possible future use
         self._dbr_metadata = {
             chtype: DBR_TYPES[chtype]()
             for chtype in (promote_type(self.data_type, use_ctrl=True),
@@ -323,7 +324,12 @@ class ChannelData:
 
     @property
     def epics_timestamp(self):
-        'EPICS timestamp as (seconds, nanoseconds) since EPICS epoch'
+        """
+        EPICS timestamp as (seconds, nanoseconds) since EPICS epoch
+
+        The innocent may be surprised to learn that the EPICS epoch is not the
+        same as the UNIX epoch.
+        """
         return timestamp_to_epics(self.timestamp)
 
     @property

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -231,14 +231,13 @@ class ChannelData:
             class_name.value = rtyp
             return class_name, b''
 
-        # for native types, there is no dbr metadata - just data
         native_to = native_type(data_type)
         values = convert_values(values=self.data, from_dtype=self.data_type,
                                 to_dtype=native_to,
                                 string_encoding=self.string_encoding,
                                 enum_strings=getattr(self, 'enum_strings', None))
 
-
+        # for native types, there is no dbr metadata - just data
         if data_type in native_types:
             return b'', values
 

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -250,7 +250,7 @@ class ChannelData:
         self._copy_metadata_to_dbr(dbr_metadata)
         return dbr_metadata, values
 
-    async def set_dbr_data(self, data, data_type, data_count, metadata):
+    async def set_dbr_data(self, data, data_type, data_count):
         '''Set data from DBR metadata/values'''
         native_from = native_type(data_type)
         self.data = convert_values(values=data, from_dtype=native_from,

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -1,3 +1,4 @@
+from functools import partial
 import time
 
 # TODO: assuming USE_NUMPY for now
@@ -7,7 +8,7 @@ from ._dbr import (DBR_TYPES, ChType, promote_type, native_type,
                    native_float_types, native_int_types, native_types,
                    timestamp_to_epics, time_types, MAX_ENUM_STRING_SIZE,
                    DBR_STSACK_STRING, AccessRights, _numpy_map,
-                   SubscriptionType)
+                   SubscriptionType, graphical_types)
 
 
 class Forbidden(Exception):
@@ -132,7 +133,7 @@ def convert_values(values, from_dtype, to_dtype, *, string_encoding='latin-1',
 class ChannelAlarm:
     def __init__(self, *, status=0, severity=0,
                  acknowledge_transient=True, acknowledge_severity=0,
-                 alarm_string=''):
+                 alarm_string='', string_encoding='latin-1'):
         """
         Parameters
         ----------
@@ -141,57 +142,100 @@ class ChannelAlarm:
         severity : ca.AlarmSeverity, optional
             Alarm severity
         """
-        self.channel_data = channel_data
-        self.status = status
-        self.severity = severity
-        self.acknowledge_transient = acknowledge_transient
-        self.acknowledge_severity = acknowledge_severity
-        self.alarm_string = alarm_string
+        dbr = DBR_STSACK_STRING()
+        self._dbr = dbr
+        self._string_encoding = string_encoding
+        self._channels = []
+        self._update_channel = {}
+        self.write(status=status, severity=severity,
+                   acknowledge_transient=acknowledge_transient,
+                   acknowledge_severity=acknowledge_severity,
+                   alarm_string=alarm_string)
+
+    status = property(lambda: self.dbr.status)
+    severity = property(lambda: self.dbr.severity)
+    acknowledge_transient = property(lambda: self.dbr.acknowledge_transient)
+    acknowledge_severity = property(lambda: self.dbr.status)
+    alarm_string = property(lambda: self.dbr.alarm_string)
+
+    def __repr__(self):
+        # TODO
+        ...
+
+    def connect(self, channel_data):
+        self._channels.append(channel_data)
+        # Obtain from ChannelData a write method that
+        # will not propagate the change back to this alarm,
+        # avoiding an infinite loop.
+        func = channel_data.connect(self)
+        self._update_channel[channel_data] = func
+        # Hand ChannelData a write method that will skip
+        # propagating the change to itself, avoiding an
+        # infinite loop.
+        return partial(self._write, caller=channel_data)
+
+    def disconnect(self, channel_data):
+        self._channels.remove(channel_data)
+        self._update_channel.pop(channel_data)
 
     def acknowledge(self):
+        # TODO
         pass
 
-    def _set_instance_from_dbr(self, dbr):
-        self.status = dbr.status
-        self.severity = dbr.severity
-        self.acknowledge_transient = (dbr.ackt != 0)
-        self.acknowledge_severity = dbr.acks
-        self.alarm_string = dbr.value.decode(self.string_encoding)
+    async def read(self):
+       return self._dbr
 
-    @classmethod
-    def _from_dbr(cls, dbr):
-        instance = cls()
-        instance._set_instance_from_dbr(dbr)
-        return instance
+    async def write(self, status=None, severity=None,
+              acknowledge_transient=None,
+              acknowledge_severity=None,
+              alarm_string=None):
+       # Call _write in such a way that all connected channels
+       # are updated.
+       await self._write(status=status, severity=severity,
+                         acknowledge_transient=acknowledge_transient,
+                         acknowledge_severity=acknowledge_severity,
+                         alarm_string=alarm_string,
+                         caller=None)
 
-    async def get_dbr_data(self, dbr=None):
-        if dbr is None:
-            dbr = DBR_STSACK_STRING()
-        dbr.status = self.status
-        dbr.severity = self.severity
-        dbr.ackt = 1 if self.acknowledge_transient else 0
-        dbr.acks = self.acknowledge_severity
-        dbr.value = self.alarm_string.encode(self.string_encoding)
-        return dbr
-
-    @property
-    def string_encoding(self):
-        return self.channel_data.string_encoding
-
+    async def _write(self, status=None, severity=None,
+              acknowledge_transient=None,
+              acknowledge_severity=None,
+              alarm_string=None, caller=None):
+        if status is not None:
+            self.dbr.status = status
+        if severity is not None:
+            self.dbr.severity = severity
+        if acknowledge_transient is not None:
+            self.dbr.ackt = 1 if acknowledge_transient else 0
+        if acknowledge_severity is not None:
+            self.dbr.acks = acknowledge_severity
+        if alarm_string is not None:
+            self.dbr.alarm_string = alarm_string.encode(self.string_encoding)
+        for channel in self._channels:
+            # Avoid infinite loop.
+            if channel is caller:
+                continue
+            func = self._update_channel[channel]
+            await func(status=status, severity=severity,
+                       acknowledge_transient=acknowledge_transient,
+                       acknowledge_severity=acknowledge_severity,
+                       alarm_string=alarm_string)
 
 class ChannelData:
+    CONVERT_ATTRS = ()
     # subclass must define a `data_type` class attribute, set to a value of the
     # ChType enum
 
     def __init__(self, *, alarm=None, string_encoding='latin-1',
-                 reported_record_type='caproto'):
+                 reported_record_type='caproto', **kwargs):
         '''Metadata and Data for a single caproto Channel
 
         Parameters
         ----------
         alarm : ChannelAlarm, optional
-            Optionally specify an allocated alarm status, which could be shared
-            among several channels
+            Optionally specify an allocated alarm, which could be shared
+            among several channels. If None (default), a ChannelAllarm
+            instance will be created using its default parameters.
         string_encoding : str, optional
             Encoding to use for strings, used both in and out
         reported_record_type : str, optional
@@ -200,13 +244,19 @@ class ChannelData:
             record or be set to something arbitrary.
             Defaults to 'caproto'
         '''
+        if alarm is None:
+            alarm = ChannelAlarm()
+        self.update_alarm = alarm.connect(self)
         self.alarm = alarm
         self.string_encoding = string_encoding
         self.reported_record_type = reported_record_type
         self._subscription_queue = None
+        # self.data_type is set as a class attribute on subclasses
+        self._dbr = DBR_TYPES[promote_type(self.data_type, use_gr=True)]()
         # cache of DBR_* structs, filled on demand
-        self._dbr_metadata = {}
-        self._initialized = False
+        self._dbr_variants = {}
+        self._stale = {}
+        self.write(hostname=None, username=None, **kwargs)
 
     def subscribe(self, queue, *sub_queue_args):
         '''Set subscription queue'''
@@ -216,16 +266,14 @@ class ChannelData:
     async def read(self, hostname, username, data_type, data_count=None):
         '''Get DBR data and native data, converted to a specific type'''
         access = self.check_access(hostname, username)
- 	if access not in (AccessRights.READ, AccessRights.READ_WRITE):
+        if access not in (AccessRights.READ, AccessRights.READ_WRITE):
             raise Forbidden("Client with hostname {} and username {} "
                             "does not have permission to read."
                             "".format(hostname, username))
-        if not self._initialized:
-            raise RuntimeError("Channel must be written to before "
-                               "it can be read.")
+
         # special cases for alarm strings and class name
         if data_type == ChType.STSACK_STRING:
-            ret = await self.alarm.get_dbr_data()
+            ret = await self.alarm.read()
             return (ret, b'')
         elif data_type == ChType.CLASS_NAME:
             class_name = DBR_TYPES[data_type]()
@@ -247,16 +295,72 @@ class ChannelData:
         if data_type in native_types:
             return b'', data
 
-        try:
-            dbr_metadata = self._dbr_metadata[data_type]
-        except KeyError:
-            dbr_metadata = DBR_TYPES[data_type]()
-            self._dbr_metadata[data_type] = dbr_metadata  # cache for reuse
+        if data_type in graphical_types:
+            return self._dbr, data
+        else:
+            # Pack the metadata into a different struct.
+            try:
+                variant = self._dbr_variants[data_type]
+            except KeyError:
+                # There are two kinds of reuse here. We can reuse the data
+                # until the next write makes it stale. We can reuse the
+                # struct that holds the data forever.
+                variant = DBR_TYPES[data_type]()
+                self._dbr_variants[data_type] = variant  # cache for reuse
+                self._stale[data_type] = True
 
-        self._copy_metadata_to_dbr(dbr_metadata)
-        return dbr_metadata, data
+            if self._stale[data_type]:
+                dbr = self._dbr
+                for field in variant._fields_:
 
-    async def write(self, hostname, username, data, data_type, metadata=None):
+
+
+        # # convert all metadata types to the target type
+        # values = convert_values(values=[getattr(self, key, 0)
+        #                                 for key in convert_attrs],
+        #                         from_dtype=self.data_type,
+        #                         to_dtype=native_type(to_type),
+        #                         string_encoding=self.string_encoding)
+        # if isinstance(values, np.ndarray):
+        #     values = values.tolist()
+        # for attr, value in zip(convert_attrs, values):
+        #     if hasattr(dbr_metadata, attr):
+        #         setattr(dbr_metadata, attr, value)
+
+
+                    setattr(variant, field, getattr(dbr, field))
+                self._stale[data_type] = False
+            return variant, data
+
+    def connect(self, alarm):
+        return partial(self._write, propagate=False)
+
+    async def write(self, hostname, username, *,
+                    data=None, data_type=None, data_count=None,
+                    timestamp=None,
+                    status=None, severity=None,
+                    acknowledge_transient=None,
+                    acknowledge_severity=None,
+                    alarm_string=None, **kwargs):
+        # Call self._write in such a way that the associated
+        # alarm is also updated and, subsequently, every other
+        # channel connected to the same alarm.
+        await self._write(self, propagate=True,
+                          hostname=hostname, username=username,
+                          data=None, data_type=None, data_count=None,
+                          timestamp=None,
+                          status=None, severity=None,
+                          acknowledge_transient=None,
+                          acknowledge_severity=None,
+                          alarm_string=None, **kwargs)
+
+    async def _write(self, propagate, hostname, username, *,
+                     data=None, data_type=None, data_count=None,
+                     timestamp=None, units=None,
+                     status=None, severity=None,
+                     acknowledge_transient=None,
+                     acknowledge_severity=None,
+                     alarm_string=None):
         """
         Set data from DBR metadata/values
 
@@ -269,94 +373,43 @@ class ChannelData:
             Posix timestamp associated with the value
             Defaults to `time.time()`
         """
+        if timestamp is None:
+            timestamp = time.time()
         access = self.check_access(hostname, username)
- 	if access not in (AccessRights.WRITE, AccessRights.READ_WRITE):
+        if access not in (AccessRights.WRITE, AccessRights.READ_WRITE):
             raise Forbidden("Client with hostname {} and username {} "
                             "does not have permission to read."
                             "".format(hostname, username))
+        for data_type in self._stale:
+            self._stale[data_type] = True
+        # Has anything to do with the alarm been updated?
+        if any(x is not None for x in (status, severity,
+                                       acknowledge_transient,
+                                       acknowledge_severity,
+                                       alarm_string)):
+            # Update the alarm, which will in turn write to any
+            # other channels with this same alarm and publish
+            # the change to any subscriptions they have.
+            self.update_alarm(self, status=None, severity=None,
+                              acknowledge_transient=None,
+                              acknowledge_severity=None,
+                              alarm_string=None)
         native_from = native_type(data_type)
-        self.data = convert_values(values=data, from_dtype=native_from,
-                                   to_dtype=self.data_type,
-                                   string_encoding=self.string_encoding,
-                                   enum_strings=getattr(self, 'enum_strings', None))
-        if timestamp is None:
-            timestamp = time.time()
-        self.timestamp = timestamp
+        data = convert_values(values=data, from_dtype=native_from,
+                              to_dtype=self.data_type,
+                              string_encoding=self.string_encoding,
+                              enum_strings=getattr(self, 'enum_strings', None))
+        dbr = self._dbr
+        dbr.value = data
+        dbr.secondsSinceEpoch, dbr.nanoSeconds = timestamp_to_epics(timestamp)
+        if units is not None:
+            dbr.units = units.encode(self.string_encoding)
+        
         if self._subscription_queue is not None:
             await self._subscription_queue.put((self,
                                                 SubscriptionType.DBE_VALUE,
                                                 self.data) +
                                                self._subscription_queue_args)
-
-    def _copy_metadata_to_dbr(self, dbr_metadata):
-        'Set all metadata fields of a given DBR type instance'
-        to_type = ChType(dbr_metadata.DBR_ID)
-
-        if hasattr(dbr_metadata, 'units'):
-            units = getattr(self, 'units', '')
-            if isinstance(units, str):
-                units = units.encode(self.string_encoding)
-            dbr_metadata.units = units
-
-        if hasattr(dbr_metadata, 'precision'):
-            dbr_metadata.precision = getattr(self, 'precision', 0)
-
-        if to_type in time_types:
-            epics_ts = self.epics_timestamp
-            dbr_metadata.secondsSinceEpoch, dbr_metadata.nanoSeconds = epics_ts
-
-        if hasattr(dbr_metadata, 'status'):
-            # many have status/severity
-            dbr_metadata.status = self.status
-            dbr_metadata.severity = self.severity
-
-        convert_attrs = ('upper_disp_limit', 'lower_disp_limit',
-                         'upper_alarm_limit', 'upper_warning_limit',
-                         'lower_warning_limit', 'lower_alarm_limit',
-                         'upper_ctrl_limit', 'lower_ctrl_limit')
-
-        if not any(hasattr(dbr_metadata, attr) for attr in convert_attrs):
-            return
-
-        # convert all metadata types to the target type
-        values = convert_values(values=[getattr(self, key, 0)
-                                        for key in convert_attrs],
-                                from_dtype=self.data_type,
-                                to_dtype=native_type(to_type),
-                                string_encoding=self.string_encoding)
-        if isinstance(values, np.ndarray):
-            values = values.tolist()
-        for attr, value in zip(convert_attrs, values):
-            if hasattr(dbr_metadata, attr):
-                setattr(dbr_metadata, attr, value)
-
-    @property
-    def epics_timestamp(self):
-        """
-        EPICS timestamp as (seconds, nanoseconds) since EPICS epoch
-
-        The innocent may be surprised to learn that the EPICS epoch is not the
-        same as the UNIX epoch.
-        """
-        return timestamp_to_epics(self.timestamp)
-
-    @property
-    def status(self):
-        '''Alarm status'''
-        return self.alarm.status
-
-    @status.setter
-    def status(self, status):
-        self.alarm.status = status
-
-    @property
-    def severity(self):
-        '''Alarm severity'''
-        return self.alarm.severity
-
-    @severity.setter
-    def severity(self, severity):
-        self.alarm.severity = severity
 
     def __len__(self):
         try:
@@ -385,6 +438,9 @@ class ChannelData:
         """
         return AccessRights.READ_WRITE
 
+    def __del__(self):
+        self.alarm.disconnect(self)
+
 
 class ChannelEnum(ChannelData):
     data_type = ChType.ENUM
@@ -408,23 +464,24 @@ class ChannelEnum(ChannelData):
 
 
 class ChannelNumeric(ChannelData):
-    def __init__(self, *, units='',
-                 upper_disp_limit=0, lower_disp_limit=0,
-                 upper_alarm_limit=0, upper_warning_limit=0,
-                 lower_warning_limit=0, lower_alarm_limit=0,
-                 upper_ctrl_limit=0, lower_ctrl_limit=0,
-                 **kwargs):
+    CONVERT_ATTRS = ('upper_disp_limit', 'lower_disp_limit',
+                    'upper_alarm_limit', 'upper_warning_limit',
+                    'lower_warning_limit', 'lower_alarm_limit',
+                    'upper_ctrl_limit', 'lower_ctrl_limit')
 
-        super().__init__(**kwargs)
-        self.units = units
-        self.upper_disp_limit = upper_disp_limit
-        self.lower_disp_limit = lower_disp_limit
-        self.upper_alarm_limit = upper_alarm_limit
-        self.upper_warning_limit = upper_warning_limit
-        self.lower_warning_limit = lower_warning_limit
-        self.lower_alarm_limit = lower_alarm_limit
-        self.upper_ctrl_limit = upper_ctrl_limit
-        self.lower_ctrl_limit = lower_ctrl_limit
+    def _write(self, *,
+              upper_disp_limit=None, lower_disp_limit=None,
+              upper_alarm_limit=None, upper_warning_limit=None,
+              lower_warning_limit=None, lower_alarm_limit=None,
+              upper_ctrl_limit=None, lower_ctrl_limit=None,
+              **kwargs):
+
+        super().write(**kwargs)
+        dbr = self._dbr
+        for attr in self.CONVERT_ATTRS:
+            val = locals()[attr]
+            if val is not None:
+                setattr(dbr, attr, val)
 
 
 class ChannelInteger(ChannelNumeric):
@@ -434,21 +491,19 @@ class ChannelInteger(ChannelNumeric):
 class ChannelDouble(ChannelNumeric):
     data_type = ChType.DOUBLE
 
-    def __init__(self, *, precision=0, **kwargs):
-        super().__init__(**kwargs)
-
-        self.precision = precision
+    def _write(self, *, precision=None, **kwargs):
+        super()._write(**kwargs)
+        if precision is not None:
+            self._dbr.precision = precision
 
 
 class ChannelChar(ChannelNumeric):
-    # 'Limits' on chars do not make much sense and are rarely used.
     data_type = ChType.CHAR
-
-    def __init__(self, *, max_length=100, **kwargs):
-        super().__init__(**kwargs)
+    # 'Limits' on chars do not make much sense and are rarely used.
+    def __init__(self, *args, max_length=100, **kwargs):
         self.max_length = max_length
+        super().__init__(*args, **kwargs)
 
 
 class ChannelString(ChannelData):
     data_type = ChType.STRING
-    # There is no CTRL or GR variant of STRING.

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -250,14 +250,16 @@ class ChannelData:
         self._copy_metadata_to_dbr(dbr_metadata)
         return dbr_metadata, values
 
-    async def set_dbr_data(self, data, data_type, data_count):
+    async def set_dbr_data(self, data, data_type, timestamp=None):
         '''Set data from DBR metadata/values'''
         native_from = native_type(data_type)
         self.data = convert_values(values=data, from_dtype=native_from,
                                    to_dtype=self.data_type,
                                    string_encoding=self.string_encoding,
                                    enum_strings=getattr(self, 'enum_strings', None))
-        self.timestamp = time.time()
+        if timestamp is None:
+            timestamp = time.time()
+        self.timestamp = timestamp
         if self._subscription_queue is not None:
             await self._subscription_queue.put((self,
                                                 SubscriptionType.DBE_VALUE,

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -192,7 +192,8 @@ class CurioVirtualCircuit:
                 '''Wait for an asynchronous caput to finish'''
                 try:
                     write_status = await db_entry.set_dbr_data(
-                        command.data, command.data_type, command.metadata)
+                        command.data, command.data_type, command.data_count,
+                        command.metadata)
                 except Exception as ex:
                     cid = self.circuit.channels_sid[command.sid].cid
                     response_command = ca.ErrorResponse(

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -416,7 +416,7 @@ class Context:
 async def _test(pvdb=None):
     logger.setLevel('DEBUG')
     if pvdb is None:
-        pvdb = {'pi': ChannelDouble(value=3.14,
+        pvdb = {'pi': ChannelDouble(data=3.14,
                                     lower_disp_limit=3.13,
                                     upper_disp_limit=3.15,
                                     lower_alarm_limit=3.12,
@@ -428,16 +428,16 @@ async def _test(pvdb=None):
                                     precision=5,
                                     units='doodles',
                                     ),
-                'enum': ChannelEnum(value='b',
+                'enum': ChannelEnum(data='b',
                                     enum_strings=['a', 'b', 'c', 'd'],
                                     ),
-                'enum2': ChannelEnum(value='bb',
+                'enum2': ChannelEnum(data='bb',
                                      enum_strings=['aa', 'bb', 'cc', 'dd'],
                                      ),
-                'int': ChannelInteger(value=96,
+                'int': ChannelInteger(data=96,
                                       units='doodles',
                                       ),
-                'char': ca.ChannelChar(value=b'3',
+                'char': ca.ChannelChar(data=b'3',
                                        units='poodles',
                                        lower_disp_limit=33,
                                        upper_disp_limit=35,
@@ -448,10 +448,10 @@ async def _test(pvdb=None):
                                        lower_ctrl_limit=30,
                                        upper_ctrl_limit=38,
                                        ),
-                'chararray': ca.ChannelChar(value=b'1234567890' * 2),
-                'str': ca.ChannelString(value='hello',
+                'chararray': ca.ChannelChar(data=b'1234567890' * 2),
+                'str': ca.ChannelString(data='hello',
                                         string_encoding='latin-1'),
-                'stra': ca.ChannelString(value=['hello', 'how is it', 'going'],
+                'stra': ca.ChannelString(data=['hello', 'how is it', 'going'],
                                          string_encoding='latin-1'),
                 }
         pvdb['pi'].alarm.alarm_string = 'delicious'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -238,10 +238,10 @@ async def run_caget(pv, *, dbr_type=None):
         raise RuntimeError('caget failed: {}'.format(stderr))
 
     if wide_mode:
-        pv, timestamp, value, stat, sevr = lines[0].split(sep)
+        pv, timestamp, data, stat, sevr = lines[0].split(sep)
         info = dict(pv=pv,
                     timestamp=timestamp,
-                    value=value,
+                    data=data,
                     status=stat,
                     severity=sevr)
     else:
@@ -304,7 +304,7 @@ str_alarm_status = ca.ChannelAlarmStatus(
 )
 
 caget_pvdb = {
-    'pi': ca.ChannelDouble(value=3.14,
+    'pi': ca.ChannelDouble(data=3.14,
                            lower_disp_limit=3.13,
                            upper_disp_limit=3.15,
                            lower_alarm_limit=3.12,
@@ -316,10 +316,10 @@ caget_pvdb = {
                            precision=5,
                            units='doodles',
                            ),
-    'enum': ca.ChannelEnum(value='b',
+    'enum': ca.ChannelEnum(data='b',
                            enum_strings=['a', 'b', 'c', 'd'],
                            ),
-    'int': ca.ChannelInteger(value=33,
+    'int': ca.ChannelInteger(data=33,
                              units='poodles',
                              lower_disp_limit=33,
                              upper_disp_limit=35,
@@ -330,7 +330,7 @@ caget_pvdb = {
                              lower_ctrl_limit=30,
                              upper_ctrl_limit=38,
                              ),
-    'char': ca.ChannelChar(value=b'3',
+    'char': ca.ChannelChar(data=b'3',
                            units='poodles',
                            lower_disp_limit=33,
                            upper_disp_limit=35,
@@ -341,7 +341,7 @@ caget_pvdb = {
                            lower_ctrl_limit=30,
                            upper_ctrl_limit=38,
                            ),
-    'str': ca.ChannelString(value='hello',
+    'str': ca.ChannelString(data='hello',
                             alarm_status=str_alarm_status,
                             reported_record_type='caproto'),
     }
@@ -409,7 +409,7 @@ def test_curio_server_with_caget(curio_server, pv, dbr_type):
         print('dbr_type', dbr_type, 'data:')
         print(data)
 
-        db_value = db_entry.value
+        db_value = db_entry.data
 
         # convert from string value to enum if requesting int
         if (db_native == ChType.ENUM and

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -297,7 +297,7 @@ async def run_caget(pv, *, dbr_type=None):
 #
 #     return lines
 
-str_alarm_status = ca.ChannelAlarmStatus(
+str_alarm_status = ca.ChannelAlarm(
     status=ca.AlarmStatus.READ,
     severity=ca.AlarmSeverity.MINOR_ALARM,
     alarm_string='alarm string',


### PR DESCRIPTION
This is in a messy state (tests aren't even close to passing) but posted for discussion.

Goals:
* [ ] Sync channels and alarms so that updates to either propagate correctly.
* [ ] Store the 'ground truth' copy of current data in a graphical DBR instead of in Python attributes. Expose properties for user-friendly access on demand.
* [ ] Handle access permissions
* [ ] Only allow updates through a function call (`write(...0`) which can handle coordinated changes, unlike updates through `setattr`.