### PR TITLE
Revert "PERF: assume input is homogeneous type"

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -888,9 +888,8 @@ class PV:
 
         if not isinstance(value, Iterable):
             value = (value, )
-        # assume input is homogeneous type
-        if isinstance(value[0], str):
-            value = tuple(map(str.encode, value))
+        value = tuple(v.encode('utf-8') if isinstance(v, str)
+                      else v for v in value)
 
         def run_callback(cmd):
             callback(*callback_data)


### PR DESCRIPTION
Reverts NSLS-II/caproto#118 in favor of https://github.com/NSLS-II/caproto/pull/112/commits/724b32d375712a8778b5cbb11e29f403e984b5b6