### PR TITLE
FIX: pass through args, kwargs in top-level get_pv

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1448,7 +1448,7 @@ def get_pv(pvname, *args, **kwargs):
     if _dflt_context is None:
         _dflt_context = PVContext()
 
-    return _dflt_context.get_pv(pvname)
+    return _dflt_context.get_pv(pvname, *args, **kwargs)
 
 
 def caput(pvname, value, wait=False, timeout=60):


### PR DESCRIPTION
I believe this was a typo, this is the only part in the `threading.get_pv` chain that doesn't pass the `*args` and `**kwargs` down to the `PV` object. These should be passed through to match the `pyepics` interface.