### PR TITLE
WIP/ENH: High level server idea

### DIFF
--- a/caproto/curio/high_level_server.py
+++ b/caproto/curio/high_level_server.py
@@ -5,14 +5,13 @@ from types import MethodType
 
 from .. import (ChannelDouble, ChannelInteger, ChannelString,
                 ChannelAlarm)
-from ..benchmarking import set_logging_level
-from .server import start_server
 
 
 logger = logging.getLogger(__name__)
 
 
-class PVSpec(namedtuple('PVSpec', 'get put attr name dtype value alarm_group')):
+class PVSpec(namedtuple('PVSpec',
+                        'get put attr name dtype value alarm_group')):
     'PV information specification'
     __slots__ = ()
     default_dtype = int
@@ -193,78 +192,3 @@ class PVGroupBase(metaclass=PVGroupMeta):
         'Generic write called for channels without `put` defined'
         logger.debug('group write of %s = %s', instance.pvspec.attr, value)
         return value
-
-
-class MyPVGroup(PVGroupBase):
-    'Example group of PVs, where the prefix is defined on instantiation'
-    # starting off with something like old-style property-like PVs:
-
-    # PV #1: {prefix}single
-    # - has custom read/write methods defined in the wrapped function
-    async def single_read(self, instance):
-        # NOTE: self is the group, instance is the channeldata instance
-        logger.debug('read single')
-        return ['a']
-
-    async def single_write(self, instance, value):
-        logger.debug('write single %r', value)
-        return value
-
-    single = pvproperty(single_read, single_write, value=['b'])
-
-    async def read_int(self, instance):
-        logger.debug('read_int of %s', instance.pvspec.attr)
-        return instance.value
-
-    # a set of 3 PVs re-using the same spec-func
-    # PV #2: {prefix}testa
-    testa = pvproperty(read_int, value=[1])
-    # PV #3: {prefix}testa
-    testb = pvproperty(read_int, value=[2])
-    # PV #4: {prefix}testa
-    testc = pvproperty(read_int, value=[3])
-
-    # PV #5: {prefix}{macro}
-    macroified = pvproperty(value=[0], name='{macro}')
-
-    # - section 2 - with new-style property-like PVs
-    # PV #6: {prefix}newstyle
-    @pvproperty(value=['c'])
-    async def newstyle(self, instance):
-        logger.debug('read newstyle')
-        return instance.value
-
-    @newstyle.putter
-    async def newstyle(self, instance, value):
-        logger.debug('write newstyle %r', value)
-        return value
-
-    # PV #7: {prefix}random - defaults to dtype of int
-    @pvproperty
-    async def random(self, instance):
-        logger.debug('read random')
-        import random
-        return random.randint(1, 100)
-
-
-def main():
-    import curio
-    from pprint import pprint
-
-    set_logging_level(logging.DEBUG)
-    logger.setLevel(logging.DEBUG)
-    logging.basicConfig()
-
-    logger.info('Starting up')
-    ioc = MyPVGroup(prefix='prefix:', macros=dict(macro='expanded'))
-
-    pprint(ioc.pvdb)
-
-    print('random using the descriptor getter is:', ioc.random)
-    print('single pvspec is:', ioc.single.pvspec)
-
-    curio.run(start_server, ioc.pvdb)
-
-
-if __name__ == '__main__':
-    main()

--- a/caproto/curio/high_level_server.py
+++ b/caproto/curio/high_level_server.py
@@ -14,10 +14,10 @@ class PvpropertyData:
     def __init__(self, *, group, pvspec, **kwargs):
         self.group = group
         self.pvspec = pvspec
-        self.getter = (MethodType(pvspec.get, self)
+        self.getter = (MethodType(pvspec.get, group)
                        if pvspec.get is not None
                        else group.group_read)
-        self.putter = (MethodType(pvspec.put, self)
+        self.putter = (MethodType(pvspec.put, group)
                        if pvspec.put is not None
                        else group.group_write)
         super().__init__(**kwargs)

--- a/caproto/curio/high_level_server.py
+++ b/caproto/curio/high_level_server.py
@@ -65,12 +65,25 @@ class PVSpec(namedtuple('PVSpec',
         if dtype is None:
             dtype = (type(value[0]) if value is not None
                      else cls.default_dtype)
+
         if get is not None:
             assert inspect.iscoroutinefunction(get), 'required async def get'
-            # TODO check args
+            sig = inspect.signature(get)
+            try:
+                sig.bind('group', 'instance')
+            except Exception as ex:
+                raise RuntimeError('Invalid signature for getter {}: {}'
+                                   ''.format(get, sig))
+
         if put is not None:
             assert inspect.iscoroutinefunction(put), 'required async def put'
-            # TODO check args
+            sig = inspect.signature(put)
+            try:
+                sig.bind('group', 'instance', 'value')
+            except Exception as ex:
+                raise RuntimeError('Invalid signature for putter {}: {}'
+                                   ''.format(put, sig))
+
         return super().__new__(cls, get, put, attr, name, dtype, value,
                                alarm_group)
 

--- a/caproto/curio/high_level_server.py
+++ b/caproto/curio/high_level_server.py
@@ -1,0 +1,270 @@
+import logging
+import inspect
+from collections import (namedtuple, OrderedDict, defaultdict)
+from types import MethodType
+
+from .. import (ChannelDouble, ChannelInteger, ChannelString,
+                ChannelAlarm)
+from ..benchmarking import set_logging_level
+from .server import start_server
+
+
+logger = logging.getLogger(__name__)
+
+
+class PVSpec(namedtuple('PVSpec', 'get put attr name dtype value alarm_group')):
+    'PV information specification'
+    __slots__ = ()
+    default_dtype = int
+
+    def __new__(cls, get=None, put=None, attr=None, name=None, dtype=None,
+                value=None, alarm_group=None):
+        if dtype is None:
+            dtype = (type(value[0]) if value is not None
+                     else cls.default_dtype)
+        if get is not None:
+            assert inspect.iscoroutinefunction(get), 'required async def get'
+            # TODO check args
+        if put is not None:
+            assert inspect.iscoroutinefunction(put), 'required async def put'
+            # TODO check args
+        return super().__new__(cls, get, put, attr, name, dtype, value,
+                               alarm_group)
+
+    def new_names(self, attr=None, name=None):
+        if attr is None:
+            attr = self.attr
+        if name is None:
+            name = self.name
+        return PVSpec(self.get, self.put, attr, name, self.dtype, self.value,
+                      self.alarm_group)
+
+
+class pvproperty:
+    'A property-like descriptor for specifying a PV in a group'
+
+    def __init__(self, get=None, put=None, **spec_kw):
+        self.attr_name = None  # to be set later
+        self.spec_kw = spec_kw
+        self.pvspec = PVSpec(get=get, put=put, **spec_kw)
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self.pvspec
+        return instance.attr_pvdb[self.attr_name]
+
+    def __set__(self, instance, value):
+        instance.attr_pvdb[self.attr_name] = value
+
+    def __delete__(self, instance):
+        del instance.attr_pvdb[self.attr_name]
+
+    def __set_name__(self, name):
+        self.attr_name = name
+        # update the PV specification with the attribute name
+        self.pvspec = self.pvspec.new_names(
+            self.attr_name,
+            self.pvspec.name
+            if self.pvspec.name is not None
+            else self.attr_name)
+
+    def putter(self, put):
+        # update PVSpec with putter
+        self.pvspec = PVSpec(self.pvspec.get, put, *self.pvspec[2:])
+        return self
+
+    def __call__(self, get, put=None):
+        # handles case where pvproperty(**spec_kw)(getter, putter) is used
+        self.pvspec = PVSpec(get, put, **self.spec_kw)
+        return self
+
+
+def expand_macros(pv, macros):
+    'Expand a PV name with Python {format-style} macros'
+    return pv.format(**macros)
+
+
+class PVGroupMeta(type):
+    'Metaclass that finds all pvproperties'
+    @classmethod
+    def __prepare__(self, name, bases):
+        # keep class dictionary items in order
+        return OrderedDict()
+
+    def __new__(metacls, name, bases, dct):
+        props = [(attr, value)
+                 for attr, value in dct.items()
+                 if isinstance(value, pvproperty)
+                 ]
+        dct['__pvs__'] = pvs = OrderedDict()
+        for attr, prop in props:
+            if prop.attr_name is None:
+                # note: for python < 3.6
+                prop.__set_name__(attr)
+
+            pvs[attr] = prop
+
+        return super().__new__(metacls, name, bases, dct)
+
+
+def channeldata_from_pvspec(group, pvspec):
+    'Create a ChannelData instance based on a PVSpec'
+    full_pvname = expand_macros(group.prefix + pvspec.name, group.macros)
+    value = (pvspec.value
+             if pvspec.value is not None
+             else group.default_values[pvspec.dtype]
+             )
+
+    cls = group.type_map[pvspec.dtype]
+    inst = cls(value=value, alarm=group.alarms[pvspec.alarm_group])
+    inst.pvspec = pvspec
+
+    # and m-m-monkey-patch away!
+
+    if pvspec.get is not None:
+        async def read_wrapper(self, data_type):
+            value = await pvspec_get(self)
+            if value is not None and value != self.value:
+                # update the internal state
+                logger.debug('value for %s updated: %r', self.pvspec, value)
+                await self.write(value)
+            return await self._read(data_type)
+
+        pvspec_get = MethodType(pvspec.get, group)
+    else:
+        async def read_wrapper(self, data_type):
+            value = await group.group_read(self)
+            if value is not None:
+                # update the internal state
+                logger.debug('group read value for %s updated: %r',
+                             self.pvspec, value)
+                await self.write(value)
+            return await self._read(data_type)
+
+    inst.read = MethodType(read_wrapper, inst)
+
+    if pvspec.put is not None:
+        pvspec_put = MethodType(pvspec.put, group)
+
+        async def verify_value(self, value):
+            logger.debug('verify value wrapper')
+            return await pvspec_put(self, value)
+    else:
+        async def verify_value(self, value):
+            logger.debug('verify value wrapper')
+            return await group.group_write(self, value)
+        # TODO read-only option
+
+    inst.verify_value = MethodType(verify_value, inst)
+    return (full_pvname, inst)
+
+
+class PVGroupBase(metaclass=PVGroupMeta):
+    'Base class for a group of PVs'
+    type_map = {
+        str: ChannelString,
+        int: ChannelInteger,
+        float: ChannelDouble,
+    }
+
+    default_values = {
+        str: '-',
+        int: 0,
+        float: 0.0,
+    }
+
+    def __init__(self, prefix, macros=None):
+        self.macros = macros if macros is not None else {}
+        self.prefix = expand_macros(prefix, macros)
+        self.alarms = defaultdict(lambda: ChannelAlarm())
+        self.pvdb = OrderedDict(channeldata_from_pvspec(self, pvprop.pvspec)
+                                for pvname, pvprop in self.__pvs__.items())
+
+        # attribute -> PV instance mapping for quick access by pvproperty
+        self.attr_pvdb = OrderedDict(
+            (attr, channeldata)
+            for attr, channeldata in zip(self.__pvs__, self.pvdb.values()))
+
+    async def group_read(self, instance):
+        'Generic read called for channels without `get` defined'
+        logger.debug('no-op group read of %s', instance.pvspec.attr)
+
+    async def group_write(self, instance, value):
+        'Generic write called for channels without `put` defined'
+        logger.debug('group write of %s = %s', instance.pvspec.attr, value)
+        return value
+
+
+class MyPVGroup(PVGroupBase):
+    'Example group of PVs, where the prefix is defined on instantiation'
+    # starting off with something like old-style property-like PVs:
+
+    # PV #1: {prefix}single
+    # - has custom read/write methods defined in the wrapped function
+    async def single_read(self, instance):
+        # NOTE: self is the group, instance is the channeldata instance
+        logger.debug('read single')
+        return ['a']
+
+    async def single_write(self, instance, value):
+        logger.debug('write single %r', value)
+        return value
+
+    single = pvproperty(single_read, single_write, value=['b'])
+
+    async def read_int(self, instance):
+        logger.debug('read_int of %s', instance.pvspec.attr)
+        return instance.value
+
+    # a set of 3 PVs re-using the same spec-func
+    # PV #2: {prefix}testa
+    testa = pvproperty(read_int, value=[1])
+    # PV #3: {prefix}testa
+    testb = pvproperty(read_int, value=[2])
+    # PV #4: {prefix}testa
+    testc = pvproperty(read_int, value=[3])
+
+    # PV #5: {prefix}{macro}
+    macroified = pvproperty(value=[0], name='{macro}')
+
+    # - section 2 - with new-style property-like PVs
+    # PV #6: {prefix}newstyle
+    @pvproperty(value=['c'])
+    async def newstyle(self, instance):
+        logger.debug('read newstyle')
+        return instance.value
+
+    @newstyle.putter
+    async def newstyle(self, instance, value):
+        logger.debug('write newstyle %r', value)
+        return value
+
+    # PV #7: {prefix}random - defaults to dtype of int
+    @pvproperty
+    async def random(self, instance):
+        logger.debug('read random')
+        import random
+        return random.randint(1, 100)
+
+
+def main():
+    import curio
+    from pprint import pprint
+
+    set_logging_level(logging.DEBUG)
+    logger.setLevel(logging.DEBUG)
+    logging.basicConfig()
+
+    logger.info('Starting up')
+    ioc = MyPVGroup(prefix='prefix:', macros=dict(macro='expanded'))
+
+    pprint(ioc.pvdb)
+
+    print('random using the descriptor getter is:', ioc.random)
+    print('single pvspec is:', ioc.single.pvspec)
+
+    curio.run(start_server, ioc.pvdb)
+
+
+if __name__ == '__main__':
+    main()

--- a/caproto/examples/curio_server_currency_conversion.py
+++ b/caproto/examples/curio_server_currency_conversion.py
@@ -1,0 +1,44 @@
+import re
+import logging
+
+import curio
+import asks  # for http requests through curio
+
+import urllib.request
+import urllib.parse
+from caproto.benchmarking import set_logging_level
+from caproto.curio.server import start_server
+from caproto.curio.high_level_server import pvproperty, PVGroupBase
+
+
+class CurrencyConversionIOC(PVGroupBase):
+    from_currency = pvproperty(value=['BTC'])
+    to_currency = pvproperty(value=['USD'])
+    amount = pvproperty(value=[1])
+
+    @property
+    def request_params(self):
+        return urllib.parse.urlencode(
+            {'a': self.amount.value[0],
+             'from': self.from_currency.value[0],
+             'to': self.to_currency.value[0],
+             })
+
+    @pvproperty(value=[0.0])
+    async def converted(self, instance):
+        resp = await asks.get('https://finance.google.com/finance/'
+                              'converter?' + self.request_params)
+        m = re.search(r'<span class=bld>([^ ]*)',
+                      resp.content.decode('latin-1'))
+        return float(m.groups()[0])
+
+
+def main(prefix, macros):
+    set_logging_level(logging.DEBUG)
+    asks.init('curio')
+    ioc = CurrencyConversionIOC(prefix=prefix, macros=macros)
+    curio.run(start_server, ioc.pvdb)
+
+
+if __name__ == '__main__':
+    main(prefix='currency:', macros={})

--- a/caproto/examples/curio_server_high_level.py
+++ b/caproto/examples/curio_server_high_level.py
@@ -1,0 +1,87 @@
+import logging
+
+from caproto.benchmarking import set_logging_level
+from caproto.curio.server import start_server
+from caproto.curio.high_level_server import (pvproperty, PVGroupBase)
+
+
+logger = logging.getLogger(__name__)
+
+
+class MyPVGroup(PVGroupBase):
+    'Example group of PVs, where the prefix is defined on instantiation'
+    # starting off with something like old-style property-like PVs:
+
+    # PV #1: {prefix}single
+    # - has custom read/write methods defined in the wrapped function
+    async def single_read(self, instance):
+        # NOTE: self is the group, instance is the channeldata instance
+        logger.debug('read single')
+        return ['a']
+
+    async def single_write(self, instance, value):
+        logger.debug('write single %r', value)
+        return value
+
+    single = pvproperty(single_read, single_write, value=['b'])
+
+    async def read_int(self, instance):
+        logger.debug('read_int of %s', instance.pvspec.attr)
+        return instance.value
+
+    # a set of 3 PVs re-using the same spec-func
+    # PV #2: {prefix}testa
+    testa = pvproperty(read_int, value=[1])
+    # PV #3: {prefix}testa
+    testb = pvproperty(read_int, value=[2])
+    # PV #4: {prefix}testa
+    testc = pvproperty(read_int, value=[3])
+
+    # PV #5: {prefix}{macro}
+    macroified = pvproperty(value=[0], name='{macro}')
+
+    # - section 2 - with new-style property-like PVs
+    # PV #6: {prefix}newstyle
+    @pvproperty(value=['c'])
+    async def newstyle(self, instance):
+        logger.debug('read newstyle')
+        return instance.value
+
+    @newstyle.putter
+    async def newstyle(self, instance, value):
+        logger.debug('write newstyle %r', value)
+        return value
+
+    # PV #7: {prefix}random - defaults to dtype of int
+    @pvproperty
+    async def random(self, instance):
+        logger.debug('read random')
+        import random
+        return random.randint(1, 100)
+
+
+def main(prefix, macros):
+    import curio
+    from pprint import pprint
+
+    set_logging_level(logging.DEBUG)
+    logger.setLevel(logging.DEBUG)
+    logging.basicConfig()
+
+    logger.info('Starting up: prefix=%r macros=%r', prefix, macros)
+    ioc = MyPVGroup(prefix=prefix, macros=macros)
+
+    # here's what accessing a pvproperty descriptor looks like:
+    print('random using the descriptor getter is:', ioc.random)
+
+    # and the pvspec is accessible as well:
+    print('single pvspec is:', ioc.single.pvspec)
+
+    # here is the auto-generated pvdb:
+    pprint(ioc.pvdb)
+
+    curio.run(start_server, ioc.pvdb)
+
+
+if __name__ == '__main__':
+    main(prefix='prefix:', macros=dict(macro='expanded'))

--- a/caproto/examples/curio_server_high_level_subgroup.py
+++ b/caproto/examples/curio_server_high_level_subgroup.py
@@ -1,0 +1,101 @@
+import random
+import logging
+
+from caproto.benchmarking import set_logging_level
+from caproto.curio.server import start_server
+from caproto.curio.high_level_server import (pvproperty, PVGroupBase,
+                                             SubGroup)
+
+
+logger = logging.getLogger(__name__)
+
+if __name__ == '__main__':
+    set_logging_level(logging.DEBUG)
+    logger.setLevel(logging.DEBUG)
+    logging.basicConfig()
+
+
+class RecordLike(PVGroupBase):
+    'Example group, mirroring a V3 record'
+
+    # stop : from being added to the prefix
+    attr_separator = ''
+
+    # PV #1: {prefix}.RTYP
+    record_type = pvproperty(name='.RTYP', value=['ai'])
+    # PV #2: {prefix}.VAL
+    value = pvproperty(name='.VAL', value=[1])
+    # PV #3: {prefix}.DESC
+    description = pvproperty(name='.DESC', value=['Description'])
+
+
+class MySubGroup(PVGroupBase):
+    'Example group of PVs, where the prefix is defined on instantiation'
+    # PV: {prefix}random - defaults to dtype of int
+    @pvproperty
+    async def random(self, instance):
+        logger.debug('read random from %s', type(self).__name__)
+        return random.randint(1, 100)
+
+
+class MyPVGroup(PVGroupBase):
+    'Example group of PVs, a mix of pvproperties and subgroups'
+
+    # PV: {prefix}random
+    @pvproperty
+    async def random(self, instance):
+        logger.debug('read random from %s', type(self).__name__)
+        return random.randint(1, 100)
+
+    # PVs: {prefix}RECORD_LIKE1.RTYP, .VAL, and .DESC
+    recordlike1 = SubGroup(RecordLike, prefix='RECORD_LIKE1')
+    # PVs: {prefix}recordlike2.RTYP, .VAL, and .DESC
+    recordlike2 = SubGroup(RecordLike)
+
+    # PV: {prefix}group1:random
+    group1 = SubGroup(MySubGroup)
+    # PV: {prefix}group2-random
+    group2 = SubGroup(MySubGroup, prefix='group2-')
+
+    # PV: {prefix}group3_prefix:random
+    @SubGroup(prefix='group3_prefix:')
+    class group3(PVGroupBase):
+        @pvproperty
+        async def random(self, instance):
+            logger.debug('read random from %s', type(self).__name__)
+            return random.randint(1, 100)
+
+    # PV: {prefix}group4:subgroup4:random
+    # (TODO BUG) {prefix}subgroup4:random
+    @SubGroup
+    class group4(PVGroupBase):
+        @SubGroup
+        class subgroup4(PVGroupBase):
+            @pvproperty
+            async def random(self, instance):
+                logger.debug('read random from %s', type(self).__name__)
+                return random.randint(1, 100)
+
+
+def main(prefix, macros):
+    import curio
+    from pprint import pprint
+
+    logger.info('Starting up: prefix=%r macros=%r', prefix, macros)
+    ioc = MyPVGroup(prefix=prefix, macros=macros)
+
+    # here's what accessing a pvproperty descriptor looks like:
+    print('random using the descriptor getter is:', ioc.random)
+
+    # and for subgroups:
+    print('subgroup4 is:', ioc.group4.subgroup4)
+    print('subgroup4.random is:', ioc.group4.subgroup4.random)
+
+    # here is the auto-generated pvdb:
+    pprint(ioc.pvdb)
+
+    curio.run(start_server, ioc.pvdb)
+
+
+if __name__ == '__main__':
+    main(prefix='prefix:', macros=dict(macro='expanded'))

--- a/doc/source/examples/custom_write.py
+++ b/doc/source/examples/custom_write.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from caproto.curio.high_level_server import pvproperty, PVGroupBase
+import pathlib
+
+
+class CustomWrite(PVGroupBase):
+    """
+    When a PV is written to, write the new value into a file as a string.
+    """
+    DIRECTORY = pathlib.Path('/tmp')
+
+    async def my_write(self, instance, value):
+        # Compose the filename based on whichever PV this is.
+        pv_name = instance.pvspec.attr  # 'A' or 'B', for this IOC
+        with open(self.DIRECTORY / pv_name, 'w') as f:
+            f.write(str(value))
+        return value
+
+    A = pvproperty(put=my_write, value=[0])
+    B = pvproperty(put=my_write, value=[0])
+
+
+if __name__ == '__main__':
+    # usage: custom_write.py <PREFIX>
+    import sys
+    import curio
+    from caproto.curio.server import start_server
+
+    ioc = CustomWrite(prefix=sys.argv[1])
+    print('PVs:', list(ioc.pvdb))
+    curio.run(start_server(ioc.pvdb))

--- a/doc/source/examples/inline_style.py
+++ b/doc/source/examples/inline_style.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from caproto.curio.high_level_server import pvproperty, PVGroupBase
+import random
+
+
+class InlineStyleIOC(PVGroupBase):
+    "An IOC with a read-only PV and a read-write PV with inline customization"
+    @pvproperty  # default dtype is int
+    async def random_int(self, instance):
+        return random.randint(1, 100)
+
+    @pvproperty(dtype=str)
+    async def random_str(self, instance):
+        return random.choice('abc')
+
+    @pvproperty(value=['c'])  # initializes value and, implicitly, dtype
+    async def A(self, instance):
+        print('reading A')
+        return instance.value
+
+    @A.putter
+    async def A(self, instance, value):
+        print('writing to A the value', value)
+        return value
+
+if __name__ == '__main__':
+    # usage: inline_style.py <PREFIX>
+    import sys
+    import curio
+    from caproto.curio.server import start_server
+
+    # Instantiate the IOC, assigning a prefix for the PV names.
+    ioc = InlineStyleIOC(prefix=sys.argv[1])
+    print('PVs:', list(ioc.pvdb))
+    
+    # Run IOC using curio.
+    curio.run(start_server(ioc.pvdb))

--- a/doc/source/examples/inline_style.py
+++ b/doc/source/examples/inline_style.py
@@ -23,6 +23,7 @@ class InlineStyleIOC(PVGroupBase):
         print('writing to A the value', value)
         return value
 
+
 if __name__ == '__main__':
     # usage: inline_style.py <PREFIX>
     import sys

--- a/doc/source/examples/macros.py
+++ b/doc/source/examples/macros.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from caproto.curio.high_level_server import pvproperty, PVGroupBase
+
+
+class MacroifiedNames(PVGroupBase):
+    """
+    
+    """
+    placeholder1 = pvproperty(value=[0], name='{beamline}:{thing}.VAL')
+    placeholder2 = pvproperty(value=[0], name='{beamline}:{thing}.RBV')
+
+
+if __name__ == '__main__':
+    # usage: macros.py <PREFIX> <BEAMLINE> <THING>
+    import sys
+    import curio
+    from caproto.curio.server import start_server
+
+    macros = {'beamline': sys.argv[2], 'thing': sys.argv[3]}
+    ioc = MacroifiedNames(prefix=sys.argv[1], macros=macros)
+    print('PVs:', list(ioc.pvdb))
+    curio.run(start_server(ioc.pvdb))

--- a/doc/source/examples/simple_ioc.py
+++ b/doc/source/examples/simple_ioc.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from caproto.curio.high_level_server import pvproperty, PVGroupBase
+
+
+class SimpleIOC(PVGroupBase):
+    "An IOC with two simple read/writable PVs"
+    A = pvproperty(value=[1])
+    B = pvproperty(value=[2])
+
+
+if __name__ == '__main__':
+    # usage: simple_ioc.py <PREFIX>
+    import sys
+    import curio
+    from caproto.curio.server import start_server
+
+    # Instantiate the IOC, assigning a prefix for the PV names.
+    ioc = SimpleIOC(prefix=sys.argv[1])
+    print('PVs:', list(ioc.pvdb))
+    
+    # Run IOC using curio.
+    curio.run(start_server(ioc.pvdb))

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -106,6 +106,7 @@ Contents
    :caption: Channel Access Sans I/O
 
    basics
+   iocs
    api
    Performance Benchmarks <https://nsls-ii.github.io/caproto/bench/#/summarylist>
    references

--- a/doc/source/iocs.rst
+++ b/doc/source/iocs.rst
@@ -73,6 +73,50 @@ Update Tallies When Each PV is Read
 
     run_example('source/examples/reading_counter.py', 'example4:')
 
+Macros for PV names
+===================
+
+.. literalinclude:: examples/macros.py
+
+.. code-block:: bash
+
+    $ source/examples/macros.py example5: XF11ID detector
+    PVs: ['example5:XF11ID:detector.VAL', 'example5:XF11ID:detector.RBV']
+
+.. ipython:: python
+    :suppress:
+
+    run_example('source/examples/macros.py', 'example5:', 'XF11ID', 'detector')
+
+Observe that the command line arguments fill in the PV names.
+
+"Inline" Style Read and Write Customization
+===========================================
+
+.. literalinclude:: examples/inline_style.py
+
+.. ipython:: python
+    :suppress:
+
+    run_example('source/examples/inline_style.py', 'example6:')
+
+.. code-block:: bash
+
+    $ source/examples/inline_style.py example6:
+    PVs: ['example6:random_int', 'example6:random_str', 'example6:A']
+
+
+.. code-block:: bash
+
+    $ caproto-get example6:random_int
+    example6:random                           87
+    $ caproto-get example6:random_int
+    example6:random                           92
+    $ caproto-get example6:random_str
+    example6:random_str                       b'b'
+    $ caproto-get example6:random_str
+    example6:random_str                       b'a'
+
 .. ipython:: python
     :suppress:
 

--- a/doc/source/iocs.rst
+++ b/doc/source/iocs.rst
@@ -1,0 +1,54 @@
+************************
+Input-Output Controllers
+************************
+
+Simple IOC
+==========
+
+.. literalinclude:: examples/simple_ioc.py
+
+.. code-block:: bash
+
+    simple_ioc.py example1:
+
+.. ipython:: python
+    :suppress:
+
+    import subprocess
+    import time
+    processes = []
+    p = subprocess.Popen(['source/examples/simple_ioc.py', 'example1:'])
+    processes.append(p)  # Clean this up later.
+    time.sleep(1)  # Give it time to start up.
+
+Now there are simple read/writable PVs named 'example1:A' and 'example1:B'.
+
+.. ipython:: python
+
+    from caproto.threading.client import get_pv
+    get_pv('example1:A').get()
+    get_pv('example1:B').get()
+
+To run a second instance of the same IOC with a different prefix:
+
+.. code-block:: bash
+
+    simple_ioc.py example2:
+
+Write to a File When a PV is Written To
+=======================================
+
+.. literalinclude:: examples/custom_write.py
+
+Update Tallies When Each PV is Read
+===================================
+
+.. literalinclude:: examples/reading_counter.py
+
+
+.. ipython:: python
+    :suppress:
+
+    # Clean up IOC processes.
+    for p in processes:
+        p.kill()

--- a/doc/source/iocs.rst
+++ b/doc/source/iocs.rst
@@ -5,21 +5,28 @@ Input-Output Controllers
 Simple IOC
 ==========
 
-.. literalinclude:: examples/simple_ioc.py
-
-.. code-block:: bash
-
-    simple_ioc.py example1:
-
 .. ipython:: python
     :suppress:
 
     import subprocess
     import time
     processes = []
-    p = subprocess.Popen(['source/examples/simple_ioc.py', 'example1:'])
-    processes.append(p)  # Clean this up later.
-    time.sleep(1)  # Give it time to start up.
+    def run_example(*args):
+        p = subprocess.Popen(args)
+        processes.append(p)  # Clean this up at the end.
+        time.sleep(1)  # Give it time to start up.
+
+.. literalinclude:: examples/simple_ioc.py
+
+.. ipython:: python
+    :suppress:
+
+    run_example('source/examples/simple_ioc.py', 'example1:')
+
+.. code-block:: bash
+
+    $ simple_ioc.py example1:
+    PVs: ['example1:A', 'example1:B']
 
 Now there are simple read/writable PVs named 'example1:A' and 'example1:B'.
 
@@ -33,22 +40,44 @@ To run a second instance of the same IOC with a different prefix:
 
 .. code-block:: bash
 
-    simple_ioc.py example2:
+    $ simple_ioc.py example2:
+    PVs: ['example2:A', 'example2:B']
 
 Write to a File When a PV is Written To
 =======================================
 
 .. literalinclude:: examples/custom_write.py
 
+.. code-block:: bash
+
+    $ custom_write.py example3:
+    PVs: ['example3:A', 'example3:B']
+
+.. ipython:: python
+    :suppress:
+
+    run_example('source/examples/custom_write.py', 'example3:')
+
 Update Tallies When Each PV is Read
 ===================================
 
 .. literalinclude:: examples/reading_counter.py
 
+.. code-block:: bash
+
+    $ reading_counter.py example4:
+    PVs: ['example4:A', 'example4:B']
+
+.. ipython:: python
+    :suppress:
+
+    run_example('source/examples/reading_counter.py', 'example4:')
 
 .. ipython:: python
     :suppress:
 
     # Clean up IOC processes.
     for p in processes:
-        p.kill()
+        p.terminate()
+    for p in processes:
+        p.wait()

--- a/doc/source/iocs.rst
+++ b/doc/source/iocs.rst
@@ -80,7 +80,7 @@ Macros for PV names
 
 .. code-block:: bash
 
-    $ source/examples/macros.py example5: XF11ID detector
+    $ macros.py example5: XF11ID detector
     PVs: ['example5:XF11ID:detector.VAL', 'example5:XF11ID:detector.RBV']
 
 .. ipython:: python
@@ -102,7 +102,7 @@ Observe that the command line arguments fill in the PV names.
 
 .. code-block:: bash
 
-    $ source/examples/inline_style.py example6:
+    $ inline_style.py example6:
     PVs: ['example6:random_int', 'example6:random_str', 'example6:A']
 
 


### PR DESCRIPTION
* Adds `pvproperty`, a property-like way of defining a caproto IOC's structure
* Adds `PVGroupBase` which allow for grouping of `pvproperty` and other `PVGroupBase`s
* Adds `SubGroup`, the class to use when nesting `PVGroup`s

There are 3 simple examples there, which should be the target of your criticism/suggestions more so than the server source itself. I think it's relatively clean. Let me know what you think, in any case!

Things that might not be obvious:
* If you don't specify a `getter` or a `putter`-handler in your `pvproperty`, the group itself handles the event in its `group_read` and `group_write` functions, respectively
* In all the get/put handlers, `self` refers to the group, as you'd expect, whereas `instance` refers to the `ChannelData` instance
* Prefixes are similar to how ophyd does it - but with the option to override the automatic behavior, and also allow for macro expansion of names
* Part of the intention of grouping PVs in the server like this is for future V4 compatibility
* Currency conversion example adds dependency [asks](https://github.com/theelous3/asks) - but this could be just removed altogether

TODO: 
* Add easy way to do `I/O Interrupt`-style PVs, where background events are causing the PV values to update
* Consider an alternate `pvproperty` that defines the `putter` instead of the `getter`, as this will be a common use case
* Alarm groups work by dictionary key in a single group; could potentially allow inheriting of parent group's alarm signal(s).
* A couple prefix/subgroup bugs
* Tests, if everyone likes this enough to proceed