### PR TITLE
CI: update circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
             python -m venv caproto-venv
             . caproto-venv/bin/activate
             pip install -r test-requirements.txt
+            # add pytest-timeout for test failure debugging purposes
+            pip install pytest-timeout
             python setup.py install
       
       - run:
@@ -74,15 +76,15 @@ jobs:
           name: Run main tests
           no_output_timeout: 2m
           command: |
-            coverage run run_tests.py -v --benchmark-disable --ignore=caproto/tests/test_bench.py
+            coverage run run_tests.py -v --benchmark-disable --ignore=caproto/tests/test_bench.py --timeout=60
             coverage combine
 
       - run:
           name: Quickly run benchmark tests
-          no_output_timeout: 1m
+          no_output_timeout: 2m
           command: |
             export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE}
-            coverage run `which py.test` -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
+            coverage run `which py.test` -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench --timeout=60
 
       - run:
           name: Report coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,35 +5,23 @@ jobs:
   build:
     working_directory: ~/caproto
     docker:
-      - image: klauer/caproto-docker:0.1.1
+      - image: klauer/caproto-docker:0.2.2
         environment:
           EPICS_CA_AUTO_ADDR_LIST: "NO"
           EPICS_CA_MAX_ARRAY_BYTES: "10000000"
+          CI_ROOT: /epics/ci
+          CI_SCRIPTS: /epics/ci/ci-scripts
     steps:
       - checkout
-      - run: 
-          name: environment configuration
-          command: |
-            DOCKER_IP=$(ip addr show eth0 |grep 'inet ' | sed -e 's/.*inet \([^\/]*\).*/\1/')
-            EPICS_CA_ADDR_LIST=$(echo $DOCKER_IP | sed -e 's/^\([0-9]\+\)\.\([0-9]\+\)\..*$/\1.\2.255.255/' )
-            echo 'export PATH=$HOME/.linuxbrew/bin:$PATH' >> $BASH_ENV
-            echo "export DOCKER_IP=$DOCKER_IP" >> $BASH_ENV
-            echo "export EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST" >> $BASH_ENV
-            echo 'source epics_env.sh' >> $BASH_ENV
-            echo '[[ -f caproto-venv/bin/activate ]] && echo "(caproto-venv)" && source caproto-venv/bin/activate' >> $BASH_ENV
-
       - run:
-          name: Run motorsim IOC in background
-          background: true
+          name: Initialize submodules
           command: |
-            cd /epics/iocs/motorsim/iocBoot/ioclocalhost
-            ../../bin/linux-x86_64/mtrSim ./st.cmd
-
-      - run:
-          name: Run pyepics test IOC in background
-          command: pyepics_testioc-run.sh
-          background: true
-
+            # TODO: need to create a machine user. for now, just init our
+            # submodule separately
+            # see: https://circleci.com/docs/1.0/github-security-ssh-keys/
+            cd $HOME/caproto
+            rm -rf .ci
+            git clone https://github.com/NSLS-II/epics-on-travis .ci
       - run:
           name: Setup virtual environment
           # after this step, all steps run in the virtual environment using $BASH_ENV
@@ -44,12 +32,27 @@ jobs:
             python setup.py install
       
       - run:
-          name: Run pyepics simulator in background
+          name: environment configuration (broadcast address, bashrc)
           command: |
-            cd
-            wget https://raw.githubusercontent.com/pyepics/testioc/master/simulator.py
-            python simulator.py
-          background: true
+            source caproto-venv/bin/activate
+            export DOCKER_IP=$(ip addr show eth0 |grep 'inet ' | sed -e 's/.*inet \([^ ]*\).*/\1/')
+            EPICS_CA_ADDR_LIST=$(python -c "import ipaddress; print(ipaddress.IPv4Network('$DOCKER_IP', strict=False).broadcast_address)")
+
+            # overwrite the address list from the CI scripts with one determined from the docker IP:
+            echo "export EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST" >> $CI_SCRIPTS/epics-config.sh
+            # and load epics-config.sh every time bash_env is sourced
+            echo 'pushd $HOME/caproto' >> $BASH_ENV
+            echo 'if [ -d .ci/ci-scripts ]; then source setup_local_dev_env.sh; fi' >> $BASH_ENV
+            echo 'popd' >> $BASH_ENV
+            # (Really should be using epics-config.sh:)
+            # echo 'source $CI_SCRIPTS/epics-config.sh' >> $BASH_ENV
+            echo '[[ -f caproto-venv/bin/activate ]] && echo "(caproto-venv)" && source caproto-venv/bin/activate' >> $BASH_ENV
+
+      - run:
+          name: Run IOCs and pyepics simulator in background
+          background: false
+          command: |
+            bash $HOME/caproto/.circleci/start-tmux.sh
 
       - run:
           name: Check IOC status using caget and caproto repeater
@@ -57,20 +60,33 @@ jobs:
             rm `which caRepeater` || /bin/true
             caproto-repeater &
             REPEATER_PID=$!
+            sleep 0.2
+
             env
-            caget XF:31IDA-OP{Tbl-Ax:X1}Mtr
+            # Double-check that they're running, although the CI scripts do that above
             caget Py:ao1
+            caget sim:mtr1
             kill $REPEATER_PID
+            sleep 2
 
       - run:
-          name: Run tests
+          name: Run main tests
+          no_output_timeout: 2m
+          command: |
+            coverage run run_tests.py -v --benchmark-disable --ignore=caproto/tests/test_bench.py
+            coverage combine
+
+      - run:
+          name: Quickly run benchmark tests
           no_output_timeout: 1m
           command: |
-            coverage run run_tests.py -v tests/
+            export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE}
+            coverage run `which py.test` -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
 
       - run:
           name: Report coverage
           command: |
+            coverage combine -a
             coverage report -m
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ jobs:
             export DOCKER_IP=$(ip addr show eth0 |grep 'inet ' | sed -e 's/.*inet \([^ ]*\).*/\1/')
             EPICS_CA_ADDR_LIST=$(python -c "import ipaddress; print(ipaddress.IPv4Network('$DOCKER_IP', strict=False).broadcast_address)")
 
-            # overwrite the address list from the CI scripts with one determined from the docker IP:
-            echo "export EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST" >> $CI_SCRIPTS/epics-config.sh
             # and load epics-config.sh every time bash_env is sourced
             echo 'pushd $HOME/caproto' >> $BASH_ENV
             echo 'if [ -d .ci/ci-scripts ]; then source setup_local_dev_env.sh; fi' >> $BASH_ENV
@@ -47,6 +45,9 @@ jobs:
             # (Really should be using epics-config.sh:)
             # echo 'source $CI_SCRIPTS/epics-config.sh' >> $BASH_ENV
             echo '[[ -f caproto-venv/bin/activate ]] && echo "(caproto-venv)" && source caproto-venv/bin/activate' >> $BASH_ENV
+            # overwrite the address list from the CI scripts with one determined from the docker IP:
+            echo "export EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST" >> $BASH_ENV
+            echo 'echo EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST' >> $BASH_ENV
 
       - run:
           name: Run IOCs and pyepics simulator in background

--- a/.circleci/start-tmux.sh
+++ b/.circleci/start-tmux.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e -x
+
+export EPICS_TMUX_SESSION=IOCs
+
+echo "Starting a new tmux session '${EPICS_TMUX_SESSION}'"
+tmux new-session -d -s ${EPICS_TMUX_SESSION} /bin/bash
+
+tmux set -g remain-on-exit on
+
+echo "Starting the pyepics test IOC..."
+tmux new-window -n 'pyepics-test_ioc' -c "$CI_SCRIPTS" \
+    "source ${BASH_ENV}; \
+    cd ${PYEPICS_IOC}/iocBoot/iocTestioc && \
+    ${PYEPICS_IOC}/bin/${EPICS_HOST_ARCH}/testioc ./st.cmd"
+
+echo "Starting the motorsim IOC..."
+tmux new-window -n 'motorsim_ioc' -c "${CI_SCRIPTS}"  \
+    "source ${BASH_ENV}; \
+    cd ${MOTORSIM_IOC}/iocBoot/ioclocalhost && \
+    ${MOTORSIM_IOC}/bin/${EPICS_HOST_ARCH}/mtrSim ./st.cmd"
+
+# -- check that all IOCs have started --
+until caget Py:ao1
+do
+  echo "Waiting for pyepics test IOC to start..."
+  sleep 0.5
+done
+
+until caget sim:mtr1
+do
+  echo "Waiting for motorsim IOC to start..."
+  sleep 0.5
+done
+
+echo "All IOCs are running in tmux!"
+
+echo "Running pyepics simulator program..."
+tmux new-window -c "${CI_SCRIPTS}" -n 'pyepics_sim' \
+    "source ${BASH_ENV}; echo $PATH; which python; \
+    cd "${PYEPICS_IOC}" && $HOME/caproto/caproto-venv/bin/python simulator.py"
+
+echo "Done - check tmux session ${EPICS_TMUX_SESSION}"

--- a/caproto/tests/_asv_shim.py
+++ b/caproto/tests/_asv_shim.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import pytest
 import logging
@@ -229,11 +228,15 @@ def find_asv_root(path, *, asv_conf_filename='asv.conf.json',
 def pytest_benchmark_update_json(config, benchmarks, output_json):
     yield
 
-    results = pytest_bench_to_asv(output_json)
-    asv_path = find_asv_root('.')
+    try:
+        results = pytest_bench_to_asv(output_json)
+        asv_path = find_asv_root('.')
 
-    logger.info('Saving asv-style JSON to %s', asv_path)
-    save_asv_results(asv_path, **results)
+        logger.info('Saving asv-style JSON to %s', asv_path)
+        save_asv_results(asv_path, **results)
+    except Exception as ex:
+        logger.exception('Failed to update pytest benchmark json; '
+                         'asv results not saved')
 
 
 def get_all_params_from_marked_test(node_or_func):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -305,7 +305,9 @@ class SharedBroadcaster:
                 for command in commands:
                     if isinstance(command, ca.VersionResponse):
                         # Check that the server version is one we can talk to.
-                        assert command.version > 11
+                        if command.version <= 11:
+                            logger.warning('Version response <= 11: %r',
+                                           command)
                     if isinstance(command, ca.SearchResponse):
                         with self._search_lock:
                             name = self.unanswered_searches.get(command.cid,

--- a/setup_local_dev_env.sh
+++ b/setup_local_dev_env.sh
@@ -13,9 +13,6 @@ if [ -d "${TRAVIS_BUILD_DIR}/.ci/ci-scripts" ]; then
     popd
     # Reset the build directory for this repository
     export TRAVIS_BUILD_DIR=${PWD}
-
-    export |grep EPIC
-    echo "BASE=${BASE} V4=${V4}"
 else
     export EPICS_HOST_ARCH=linux-x86_64
     export EPICS_CA_ADDR_LIST=127.255.255.255
@@ -31,3 +28,6 @@ else
 
     source ${TRAVIS_BUILD_DIR}/.ci/epics-config.sh
 fi
+
+export |grep EPIC
+echo "BASE=${BASE} PVA=${PVA}"

--- a/setup_local_dev_env.sh
+++ b/setup_local_dev_env.sh
@@ -8,10 +8,14 @@ export TRAVIS_BUILD_DIR=${PWD}
 # If the CI scripts are available, use the potentially updated version
 if [ -d "${TRAVIS_BUILD_DIR}/.ci/ci-scripts" ]; then
     pushd ${TRAVIS_BUILD_DIR}/.ci
+    echo "Calling sub-module dev env script"
     source setup_local_dev_env.sh
     popd
     # Reset the build directory for this repository
     export TRAVIS_BUILD_DIR=${PWD}
+
+    export |grep EPIC
+    echo "BASE=${BASE} V4=${V4}"
 else
     export EPICS_HOST_ARCH=linux-x86_64
     export EPICS_CA_ADDR_LIST=127.255.255.255


### PR DESCRIPTION
This is in a much better spot now, but there's still a lot left to do on the time sink that is CI.

* The tests are running natively in a docker image I created which contains EPICS 3.14, 3.15, 3.16, motor, areaDetector, and PVA libraries (using [epics-on-travis](https://github.com/klauer/epics-on-travis) and [caproto-docker](https://github.com/klauer/caproto-docker)).
* IOCs run on tmux in the background when started up
* As-is, only one configuration is actually tested (no conda, so 3.6 only)

**TODO**
- [ ] Some threading tests are failing
- [ ] Some benchmarks are failing (no output after 1 minute kills the build)
- [ ] Install conda on the docker image
- [ ] Get matrixed builds working somehow