### PR TITLE
ENH: Issue a log message when the repeater is up.

### DIFF
--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -81,6 +81,7 @@ def _run_repeater(server_sock, bind_addr):
     clients = {}
     broadcaster = caproto.Broadcaster(our_role=caproto.SERVER)
 
+    logger.info("Repeater is listening on %s:%d", bind_host, bind_port)
     while True:
         msg, addr = server_sock.recvfrom(MAX_UDP_RECV)
         host, port = addr


### PR DESCRIPTION
It's nice to have a way to know that the repeater has started.
Previously even verbose logging would not tell you this. In this PR,
the `-q/--quiet` flag suppresses this message.