### PR TITLE
CI: run IOCs/simulator on procserv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
       - perl
       - re2c
       - tmux
-      - strace
+      - procserv
 
 cache:
   directories:
@@ -50,17 +50,16 @@ before_install:
   - export CI_SCRIPTS=${TRAVIS_BUILD_DIR}/.ci/ci-scripts
   - source ${CI_SCRIPTS}/epics-config.sh
   - bash .ci/install-from-release.sh "https://github.com/klauer/epics-on-travis/releases/download/${PACKAGED_DEPS}"
-  - bash ${CI_SCRIPTS}/run-epics-iocs.sh
+  - bash ${CI_SCRIPTS}/run-epics-iocs-on-procserv.sh
   - pip install pyepics numpy
-  - sleep 5.0
-  - bash ${CI_SCRIPTS}/run-pyepics-simulator.sh
+  - bash ${CI_SCRIPTS}/run-pyepics-simulator.sh procserv
 
 install:
   - pip install .
   - pip install --quiet --upgrade cython
 
 script:
-  - caget Py:ao1 sim:mtr1
+  - caget Py:ao1 sim:mtr1 13SIM1:image1:PluginType_RBV
 
   # Kill caRepeater if it's running - we want to test caproto-repeater later.
   - pgrep -a caRepeater && killall caRepeater

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ python:
 env:
   matrix:
     - BASE=R3.14.12.6 PVA= BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-9 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.6/epics-ci-0.6_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2 \
-      BUILD_DOCS=false
+      PACKAGED_DEPS=0.7/epics-ci-0.7_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2 \
+      BUILD_DOCS=0
     - BASE=R3.15.5 PVA=4.7.0 BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-9 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.6/epics-ci-0.6_R3.15.5_pva4.7.0_areadetector3-2_motor6-9.tar.bz2 \
-      BUILD_DOCS=true
+      PACKAGED_DEPS=0.7/epics-ci-0.7_R3.15.5_pva4.7.0_areadetector3-2_motor6-9.tar.bz2 \
+      BUILD_DOCS=1
     # pyepics test ioc segfaults on R3.16.1 and R7.0.1.1:
-    # - BASE=R3.16.1 PVA=4.7.0 BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2 \
-    #   PACKAGED_DEPS=0.6/epics-ci-0.6_R3.16.1_pva4.7.0_areadetector3-2_motor6-10.tar.bz2 \
-    #   BUILD_DOCS=false
-    # - BASE=R7.0.1.1 PVA= BUSY=1-7 SEQ=2.2.5 ASYN=4-33 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2
-    #   PACKAGED_DEPS=0.6/epics-ci-0.6_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2 \
-    #   BUILD_DOCS=false
+    - BASE=R3.16.1 PVA=4.7.0 BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2 \
+      PACKAGED_DEPS=0.7/epics-ci-0.7_R3.16.1_pva4.7.0_areadetector3-2_motor6-10.tar.bz2 \
+      BUILD_DOCS=0
+    - BASE=R7.0.1.1 PVA= BUSY=1-7 SEQ=2.2.5 ASYN=4-33 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2
+      PACKAGED_DEPS=0.7/epics-ci-0.7_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2 \
+      BUILD_DOCS=0
   global:
     - secure: "Hnz9c6x13kaAc7IqH4/wJWNel2rzEC8/x0KhFoGLVLHjmiH1LMmpGh/P5CPADlmKS80WFz4vhJ0YtSjtHCPI+9Y2aBGn8z732WM86OyGHITviCMTxtyVZfRFCkOAVlU0qpIyWu4p0rEfxrXCztSKE4bBO/wWnFhGGw9CJROnFhJwoJlbI9i28zscyeGsdqHNUfXHkyUAN3c3LKoYZgnJco5HiHLwXVvsy3DMkvOizLgslf6lrHwnQOT1F49ShgPcGGWpkuRARXkGII7lB0LOn2TBoTzmhgjoC3OmC4nZGJfzitwH9+nHc+iJ3mTlshsXb366B/D5TNVIL/4rzYV8zw49DogQIWYtECK4/z7fOzG61yCU33b3aeXU2OI4k5eZ2qN3gp3KQ4+PWyCMTHsBVgs6o49K1HWtFuuFLuhUPT4FVs2Pzz6yTka9NUukPO1LoTeQAUvGxRbc/15CjIWXtqqzEGmlPi8AFEo2kw33EtTawMU9w8nzAfdk5DX28Qcuzh9XA9nVUD0j7Rum7nGY1f5+icXh0FsOuP1uHt82bXIYvw3rey3RkWcqVcniJXlkq0bAZM/ZSXWX5VHyQ2e7C4kxCdnzVqjgtlGT2ARSlD6o8FKKRKTAKD7kQ9ajTjZHRhO+xbvP+X4K9GlbGvPyU9bnDFa14fXBJS4dTMd8GgQ="
 
@@ -52,11 +52,12 @@ before_install:
   - bash .ci/install-from-release.sh "https://github.com/klauer/epics-on-travis/releases/download/${PACKAGED_DEPS}"
   - bash ${CI_SCRIPTS}/run-epics-iocs.sh
   - pip install pyepics numpy
+  - sleep 5.0
   - bash ${CI_SCRIPTS}/run-pyepics-simulator.sh
 
 install:
   - pip install .
-  - pip install --upgrade cython
+  - pip install --quiet --upgrade cython
 
 script:
   - caget Py:ao1 sim:mtr1
@@ -71,23 +72,24 @@ script:
   - coverage report -m
 
   - export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE}
-  - py.test -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
-  # deploy asv results here?
+  - coverage run -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
+  - coverage combine
 
   - set -e
   # Install deps for building the docs.
-  - pip install --upgrade --global-option='--without-libyaml' pyyaml
+  - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
   # directly install second layer deps to work around easy_install bug
-  - pip install cryptography cffi pycparser
-  - pip install --upgrade -r docs-requirements.txt
+  - pip install --quiet cryptography cffi pycparser
+  - pip install --quiet --upgrade -r docs-requirements.txt
   # Run a CA Repeater for the docs examples to use.
   - caproto-repeater &
   # Build the docs.
   - pushd doc
   - make html
   - popd
+
   # Upload the docs to gh-pages.
-  - if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'NSLS-II/caproto' && $BUILD_DOCS == true && $TRAVIS_BRANCH == 'master' ]]; then
+  - if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'NSLS-II/caproto' && $BUILD_DOCS == 1 && $TRAVIS_BRANCH == 'master' ]]; then
         doctr deploy --key-path=doc/github_deploy_key.enc .;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - coverage report -m
 
   - export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE}
-  - coverage run -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
+  - coverage run run_tests.py -v --benchmark-only --benchmark-json=pytest_bench.json --benchmark-columns=mean,median,rounds,iterations -k bench
   - coverage combine
 
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ addons:
   apt:
     packages:
       - graphviz  # for building docs
-      - libreadline6-dev  # epics deps
-      - libncurses5-dev
-      - perl
-      - re2c
-      - tmux
       - procserv
 
 cache:


### PR DESCRIPTION
This may increase test reliability, as procserv will automatically restart the crashing IOC (pyepics test IOC on 3.16/7)

Let's merge this and rebase #161 on top (a couple commits from there are cherry-picked here). 