### PR TITLE
FIX: Use non-goofy defaults for host and client name in threading client.

### DIFF
--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -8,12 +8,8 @@
 # Responses.
 import itertools
 import logging
-import getpass
-import socket
 import collections
 
-# N.B. We do no networking whatsoever in caproto. We only use socket for
-# socket.gethostname() to give a nice default for a HostNameRequest command.
 from ._commands import (AccessRightsResponse, CreateChFailResponse,
                         ClearChannelRequest, ClearChannelResponse,
                         ClientNameRequest, CreateChanRequest,
@@ -482,25 +478,22 @@ class ClientChannel(_BaseChannel):
                                  priority=self.circuit.priority)
         return command
 
-    def host_name(self, host_name=None):
+    def host_name(self, host_name):
         """
         Generate a valid :class:`HostNameRequest`.
 
         Parameters
         ----------
-        host_name : string, optional
-            defaults to output of ``socket.gethostname()``
+        host_name : string
 
         Returns
         -------
         HostNameRequest
         """
-        if host_name is None:
-            host_name = socket.gethostname()
         command = HostNameRequest(host_name)
         return command
 
-    def client_name(self, client_name=None):
+    def client_name(self, client_name):
         """
         Generate a valid :class:`ClientNameRequest`.
 
@@ -513,8 +506,6 @@ class ClientChannel(_BaseChannel):
         -------
         ClientNameRequest
         """
-        if client_name is None:
-            client_name = getpass.getuser()
         command = ClientNameRequest(client_name)
         return command
 

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -16,6 +16,7 @@ import argparse
 import ast
 from collections import Iterable
 from datetime import datetime
+import getpass
 import logging
 import os
 import time
@@ -138,8 +139,8 @@ def make_channel(pv_name, logger, udp_sock, priority, timeout):
     try:
         # Initialize our new TCP-based CA connection with a VersionRequest.
         send(chan.circuit, ca.VersionRequest(priority=priority, version=13))
-        send(chan.circuit, chan.host_name())
-        send(chan.circuit, chan.client_name())
+        send(chan.circuit, chan.host_name(socket.gethostname()))
+        send(chan.circuit, chan.client_name(getpass.getuser()))
         send(chan.circuit, chan.create())
         t = time.monotonic()
         while True:

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -6,6 +6,8 @@ import caproto._utils
 import caproto.threading.client
 import sys
 import time
+import socket
+import getpass
 
 from caproto.threading.client import (Context, SharedBroadcaster, PV, logger,
                                       ContextDisconnectedError)
@@ -201,3 +203,16 @@ def test_subscriptions(ioc, context):
             time.sleep(0.1)
 
     assert monitor_values[1:] == [1, 2, 3]
+
+
+def test_client_and_host_name(shared_broadcaster):
+    ctx = Context(broadcaster=shared_broadcaster, host_name='foo')
+    assert ctx.host_name == 'foo'
+
+    ctx = Context(broadcaster=shared_broadcaster, client_name='bar')
+    assert ctx.client_name == 'bar'
+
+    # test defaults
+    ctx = Context(broadcaster=shared_broadcaster)
+    assert ctx.host_name == socket.gethostname()
+    assert ctx.client_name == getpass.getuser()


### PR DESCRIPTION
Also refactors. See commit message.