### PR TITLE
FIX: threading callback queue

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -873,7 +873,6 @@ class VirtualCircuitManager:
             elif isinstance(command, ca.EventAddResponse):
                 sub = self.subscriptions[command.subscriptionid]
                 self.callback_queue.put((time.monotonic(), sub, command))
-                # sub.process(command)
             elif isinstance(command, ca.EventCancelResponse):
                 self.subscriptions.pop(command.subscriptionid)
             elif isinstance(command, ca.CreateChanResponse):


### PR DESCRIPTION
Fixes NSLS-II/ophyd#524 by avoiding callback deadlock

Solution was the first that came to mind (ophyd pseudo positioner tests all pass locally) - eventually smarter handling using a thread pool or throwing out monitors that are too far backlogged may be worthwhile.