### PR TITLE
REF: add assuredly controversial DbrStringArray

### DIFF
--- a/caproto/sync/__init__.py
+++ b/caproto/sync/__init__.py
@@ -1,0 +1,2 @@
+from . import repeater
+from . import client

--- a/caproto/tests/test_serialization.py
+++ b/caproto/tests/test_serialization.py
@@ -162,8 +162,8 @@ payloads = [
 
     (ca.ChannelType.STRING, 1, b'abc'.ljust(40, b'\x00'), None),
     (ca.ChannelType.STRING, 3, 3 * b'abc'.ljust(40, b'\x00'), None),
-    (ca.ChannelType.STRING, 3, numpy.array(['abc', 'def'], '>S40'), None),
-    (ca.ChannelType.STRING, 3, numpy.array(['abc', 'def'], 'S40'), None),
+    (ca.ChannelType.STRING, 2, numpy.array(['abc', 'def'], '>S40'), None),
+    (ca.ChannelType.STRING, 2, numpy.array(['abc', 'def'], 'S40'), None),
     (ca.ChannelType.CHAR, 1, b'z', None),
     (ca.ChannelType.CHAR, 3, b'abc', None),
 ]


### PR DESCRIPTION
A bug in the current handling of strings was highlighted when running:
```python
color_mode = caget('13SIM1:image1:ColorMode_RBV', verbose=True).data[0].decode('ascii')
```

This would fail when the buffer from EPICS had garbage after the first null terminator, because `native_to_builtin` wasn't stripping it away effectively.

Other layers (sync, curio, trio) and especially the user should not have to worry about finding null terminators in DBR_STRING types (single- or multi-string lists). Current master returns `np.array` with a dtype of '<S40' which, while accurate, is rather inconvenient to work with.

That being said, we could just tweak `native_to_builtin` to remove everything after the null terminator, then `ljust` with null terminator chars, using a np.array dtype='<S40' as the current master. Instead of that safe route, I decided to submit a PR that @danielballan and @tacaswell will assuredly turn their noses up at :) .