### PR TITLE
REF: rework sync client search/register a bit

### DIFF
--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -170,8 +170,11 @@ def make_channel(pv_name, logger, udp_sock, priority, timeout):
 
 
 def spawn_repeater(logger):
-    subprocess.Popen(['caproto-repeater', '--quiet'], cwd="/",
-                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    try:
+        subprocess.Popen(['caproto-repeater', '--quiet'], cwd="/",
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception:
+        logger.exception('Failed to spawn repeater.')
     logger.debug('Spawned caproto-repeater process.')
 
 

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -104,7 +104,6 @@ def search(pv_name, logger, udp_sock, timeout, *, max_retries=2):
     retry_timeout = timeout / max((max_retries, 1))
     t = time.monotonic()
     retry_at = t + retry_timeout
-    registered = False
 
     try:
         orig_timeout = udp_sock.gettimeout()
@@ -123,9 +122,6 @@ def search(pv_name, logger, udp_sock, timeout, *, max_retries=2):
             for command in commands:
                 if isinstance(command, ca.SearchResponse) and command.cid == 0:
                     return ca.extract_address(command)
-                elif not registered and b.registered:
-                    registered = True
-                    logger.debug('Registered with the repeater')
             else:
                 # None of the commands we have seen are a reply to our request.
                 # Receive more data.

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -150,7 +150,7 @@ def make_channel(pv_name, logger, udp_sock, priority, timeout):
         t = time.monotonic()
         while True:
             try:
-                commands = recv(chan.circuit)
+                recv(chan.circuit)
                 if time.monotonic() - t > timeout:
                     raise socket.timeout
             except socket.timeout:


### PR DESCRIPTION
This hopefully should make the CLI tests fail a bit less frequently.

In summary:
* multiple search requests (could use improvement)
* registration response not waited for