### PR TITLE
WIP: Test on Windows with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+skip_tags: true
+
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
+
+build_script:
+  - "git --no-pager log -n2"
+  - "echo %APPVEYOR_REPO_COMMIT%"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;;%PATH%"
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - "pip install ."
+  - "pip install -Ur test-requirements.txt"
+  - "pip install codecov"
+
+test_script:
+  - "mkdir empty"
+  - "cd empty"
+  # Make sure it's being imported from where we expect
+  - "python -c \"import os, caproto; print(os.path.dirname(caproto.__file__))\""
+  # - "coverage run run_tests.py -v --benchmark-disable --timeout=50 --log-format=\"%(asctime)s %(levelname)s (%(threadName)s) %(message)s\" --log-date-format=\"%H:%M:%S,%03d\""
+  # - "coverage combine"
+  # - "coverage report -m"


### PR DESCRIPTION
- [x] Install and import caproto, following a template provided by trio. [So far, so good.](https://ci.appveyor.com/project/DanielAllan/caproto)
- [ ] Switch all ioc_examples to use trio instead of curio.
- [ ] Skip (on Windows only) all tests involving curio, which seems to not support Windows at all.
- [ ] Get some epics-base stuff running to test against (???) -- or simply skip anything that doesn't test against caproto IOCs.
- [ ] Write a variant of `caproto.threading.client.SelectorThread` for Windows. (The current implementation uses a built-in Python module only available on UNIX.)
- [ ] ~Get appveyor to run on PR branches (notice this branch is on upstream).~ Maybe this works now? Not 100% sure yet.
- [x] Integrate with GitHub to get the box by the merge button.

Possibly of interest to @johnsinsheimer.