### PR TITLE
Make beacon send failures produce more helpful errors.

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -9,6 +9,7 @@ import enum
 import json
 import threading
 from collections import namedtuple
+from warnings import warn
 
 try:
     import netifaces
@@ -126,12 +127,19 @@ def get_environment_variables():
                     EPICS_CAS_IGNORE_ADDR_LIST='',
                     )
 
-    def get_value(env_var):
-        default = defaults[env_var]
-        value = os.environ.get(env_var, default)
-        return type(default)(value)
-
-    return dict((env_var, get_value(env_var)) for env_var in defaults.keys())
+    result = dict(os.environ)
+    # Handled coupled items.
+    if (result.get('EPICS_CA_ADDR_LIST') and
+            result.get('EPICS_CA_AUTO_ADDR_LIST', '').upper() != 'NO'):
+        warn("EPICS_CA_ADDR_LIST is set but will be ignored because "
+             "EPICS_CA_AUTO_AUTO_ADDR_LIST is not set to 'no'.")
+    if (result.get('EPICS_CAS_BEACON_ADDR_LIST') and
+            result.get('EPICS_CAS_AUTO_BEACON_ADDR_LIST', '').upper() != 'NO'):
+        warn("EPICS_CAS_BEACON_ADDR_LIST is set but will be ignored because "
+             "EPICS_CAS_AUTO_BEACON_ADDR_LIST is not set to 'no'.")
+    for k, v in defaults.items():
+        result.setdefault(k, v)
+    return result
 
 
 def get_address_list():

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -507,7 +507,15 @@ class Context:
                                          self.host)
             bytes_to_send = self.broadcaster.send(beacon)
             for addr_port in addresses:
-                await self.udp_sock.sendto(bytes_to_send, addr_port)
+                try:
+                    await self.udp_sock.sendto(bytes_to_send, addr_port)
+                except IOError:
+                    logger.exception("Failed to send beacon to %r. Try "
+                                     "setting "
+                                     "EPICS_CAS_BEACON_AUTO_ADDR_LIST=no and "
+                                     "EPICS_CAS_BEACON_ADDR_LIST=<addresses>.",
+                                     addr_port)
+                    raise
             self.beacon_count += 1
             await curio.sleep(beacon_period)
 

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -169,4 +169,9 @@ def test_auto_addr_list_warnings():
             assert not record
 
     finally:
+        # Restore env as it was.
+        os.environ.pop('EPICS_CA_AUTO_ADDR_LIST', None)
+        os.environ.pop('EPICS_CA_ADDR_LIST', None)
+        os.environ.pop('EPICS_CAS_AUTO_BEACON_ADDR_LIST', None)
+        os.environ.pop('EPICS_CAS_BEACON_ADDR_LIST', None)
         os.environ.update(orig)

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -140,3 +140,33 @@ def test_parse_record_bad_filters(pvname, expected_tuple):
         ...
     else:
         raise ValueError(f'Expected failure, instead returned {filter_}')
+
+
+def test_auto_addr_list_warnings():
+    try:
+        orig = dict(os.environ)
+        os.environ.pop('EPICS_CA_AUTO_ADDR_LIST', None)
+        os.environ.pop('EPICS_CA_ADDR_LIST', None)
+        os.environ.pop('EPICS_CAS_AUTO_BEACON_ADDR_LIST', None)
+        os.environ.pop('EPICS_CAS_BEACON_ADDR_LIST', None)
+
+        with pytest.warns(None) as record:
+            ca.get_environment_variables()  # no warning
+            assert not record
+        os.environ['EPICS_CA_ADDR_LIST'] = '127.0.0.1'
+        with pytest.warns(UserWarning):
+            ca.get_environment_variables()
+        os.environ['EPICS_CA_AUTO_ADDR_LIST'] = 'no'
+        with pytest.warns(None) as record:
+            ca.get_environment_variables()  # no warning
+            assert not record
+        os.environ['EPICS_CAS_BEACON_ADDR_LIST'] = '127.0.0.1'
+        with pytest.warns(UserWarning):
+            ca.get_environment_variables()
+        os.environ['EPICS_CAS_AUTO_BEACON_ADDR_LIST'] = 'no'
+        with pytest.warns(None) as record:
+            ca.get_environment_variables()  # no warning
+            assert not record
+
+    finally:
+        os.environ.update(orig)

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -513,7 +513,15 @@ class Context:
                                          self.host)
             bytes_to_send = self.broadcaster.send(beacon)
             for addr_port in addresses:
-                await self.udp_sock.sendto(bytes_to_send, addr_port)
+                try:
+                    await self.udp_sock.sendto(bytes_to_send, addr_port)
+                except IOError:
+                    logger.exception("Failed to send beacon to %r. Try "
+                                     "setting "
+                                     "EPICS_CAS_BEACON_AUTO_ADDR_LIST=no and "
+                                     "EPICS_CAS_BEACON_ADDR_LIST=<addresses>.",
+                                     addr_port)
+                    raise
             self.beacon_count += 1
             await trio.sleep(beacon_period)
 


### PR DESCRIPTION
This does two things:

1. Warns when `*_ADDR_LIST` is set but `*_AUTO_ADDR_LIST` is unset or 'yes', such that
   the content of `*_ADDR_LIST` will just be ignored.
2. Includes the name of the interface in the error message.

Example failure with two helpful hints in it now, thanks to this PR:

```
$ spoof-beamline
/Users/dallan/Documents/Repos/caproto/caproto/_utils.py:134: UserWarning: EPICS_CA_ADDR_LIST is set but will be ignored because EPICS_CA_AUTO_AUTO_ADDR_LIST is not set to 'no'.
  warn("EPICS_CA_ADDR_LIST is set but will be ignored because "
/Users/dallan/Documents/Repos/caproto/caproto/_utils.py:138: UserWarning: EPICS_CAS_BEACON_ADDR_LIST is set but will be ignored because EPICS_CAS_AUTO_BEACON_ADDR_LIST is not set to 'no'.
  warn("EPICS_CAS_BEACON_ADDR_LIST is set but will be ignored because "
Failed to send beacon to ('192.168.86.255', 5065). Try setting EPICS_CAS_BEACON_AUTO_ADDR_LIST=no and EPICS_CAS_BEACON_ADDR_LIST=<addresses>.
Traceback (most recent call last):
  File "/Users/dallan/Documents/Repos/caproto/caproto/curio/server.py", line 511, in broadcast_beacon_loop
    await self.udp_sock.sendto(bytes_to_send, addr_port)
  File "/Users/dallan/miniconda3/envs/dd/lib/python3.6/site-packages/curio/io.py", line 251, in sendto
    return self._socket.sendto(bytes, flags, address)
PermissionError: [Errno 13] Permission denied
Failed to send beacon to ('192.168.36.255', 5065). Try setting EPICS_CAS_BEACON_AUTO_ADDR_LIST=no and EPICS_CAS_BEACON_ADDR_LIST=<addresses>.
```