### PR TITLE
Fix v12 support

### DIFF
--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -408,7 +408,10 @@ class _BaseChannel:
         if data_type is None:
             data_type = self.native_data_type
         if data_count is None:
-            data_count = 0
+            if self.protocol_version >= 13:
+                data_count = 0
+            else:
+                data_count = self.native_data_count
         return data_type, data_count
 
     def state_changed(self, role, old_state, new_state, command):

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -71,6 +71,7 @@ class VirtualCircuit:
             raise CaprotoRuntimeError("Client-side VirtualCircuit requires a "
                                       "non-None priority at initialization "
                                       "time.")
+        self.protocol_version = DEFAULT_PROTOCOL_VERSION
 
     @property
     def host(self):
@@ -289,6 +290,7 @@ class VirtualCircuit:
                 chan.access_rights = command.access_rights
             elif isinstance(command, CreateChanResponse):
                 chan.sid = command.sid
+                chan.protocol_version = self.protocol_version
                 self.channels_sid[chan.sid] = chan
             elif isinstance(command, ClearChannelResponse):
                 self.channels_sid.pop(chan.sid)
@@ -322,6 +324,11 @@ class VirtualCircuit:
                 raise err("priority {} does not match previously set priority "
                           "of {} for this circuit".format(command.priority,
                                                           self.priority))
+
+        if isinstance(command, VersionResponse):
+            protocol_version = self.protocol_version = command.version
+            for cid, chan in self.channels.items():
+                chan.protocol_version = protocol_version
 
     def disconnect(self):
         """
@@ -378,9 +385,8 @@ class _BaseChannel:
     # Base class for ClientChannel and ServerChannel, which add convenience
     # methods for composing requests and repsponses, respectively. All of the
     # important code is here in the base class.
-    def __init__(self, name, circuit, cid=None,
-                 protocol_version=DEFAULT_PROTOCOL_VERSION):
-        self.protocol_version = protocol_version
+    def __init__(self, name, circuit, cid=None):
+        self.protocol_version = circuit.protocol_version
         self.name = name
         self.circuit = circuit
         if cid is None:

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -324,9 +324,14 @@ class VirtualCircuit:
                 raise err("priority {} does not match previously set priority "
                           "of {} for this circuit".format(command.priority,
                                                           self.priority))
+            protocol_version = min(self.protocol_version, command.version)
+            self.protocol_version = protocol_version
+            for cid, chan in self.channels.items():
+                chan.protocol_version = protocol_version
 
         if isinstance(command, VersionResponse):
-            protocol_version = self.protocol_version = command.version
+            protocol_version = min(self.protocol_version, command.version)
+            self.protocol_version = protocol_version
             for cid, chan in self.channels.items():
                 chan.protocol_version = protocol_version
 


### PR DESCRIPTION
This needs some testing, but it works against a real v12 server that was failing before.

The fix is to:

 - carry the version information on the circuit (can you have mixed version channels on the same circuit?)
 - aggressively update the protocol version if we find out that it is a lower version than we asked for
 - break the API on `_BaseChanel` to get the version from the circuit

Maybe we should prevent a create channel command from going out until we have a VersionResponse?