### PR TITLE
BLD: Use extras_require to implement optional dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ classifiers = [
     'License :: OSI Approved :: BSD License'
 ]
 
+
+extras_require = {
+  'standard': ['netifaces', 'numpy'],
+  'async': ['asks', 'curio', 'trio'],
+}
+extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
+
+
 setup(name='caproto',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
@@ -33,5 +41,6 @@ setup(name='caproto',
                 ],
       scripts=glob.glob('scripts/*'),
       python_requires='>=3.6',
-      classifiers=classifiers
+      classifiers=classifiers,
+      extras_require=extras_require
       )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ pytest-rerunfailures
 asv
 asks
 ophyd
-trio==0.4.0
+trio


### PR DESCRIPTION
Closes https://github.com/NSLS-II/caproto/issues/209

This partitioning of dependencies anticipates three use cases:

* Give me nothing but caproto (`pip install caproto`)
* Give me everything (`pip install caproto[complete]`)
* Skip the async libs but give me a full-featured sync, threading,
  and pyepics-compat clients
  (`pip install caproto[standard]`)

We also have `pip install caproto[async]` but I'm not sure how
popular that will be.