### PR TITLE
FIX: Shutdown socket properly.

### DIFF
--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -99,7 +99,7 @@ class Context(_Context):
                                                              addr))
                 self._server_tasks.append(tsk)
         finally:
-            s.shutdown()
+            s.shutdown(socket.SHUT_WR)
             s.close()
             s = None
 


### PR DESCRIPTION
``socket.shutdown`` has a required argument. Because this happens in a cleanup
step it was not being caught but it generated error messages in the test logs.