### PR TITLE
FIX: Avoid race between client unsubscribe and circuit disconnect.

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -476,7 +476,7 @@ class ChannelData:
         await queue.put(((sub_spec,), metadata, values))
 
     async def unsubscribe(self, queue, sub_spec):
-        self._queues[queue][sub_spec.data_type].remove(sub_spec)
+        self._queues[queue][sub_spec.data_type].discard(sub_spec)
 
     async def auth_read(self, hostname, username, data_type, *,
                         user_address=None):


### PR DESCRIPTION
Example of the issue that this solves:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/curio/kernel.py", line 736, in _run_coro
    trap = current._send(current.next_value)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/curio/task.py", line 167, in _task_runner
    return await coro
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/curio/network.py", line 106, in run_client
    await client_connected_task(client, addr)
  File "/home/travis/build/NSLS-II/caproto/caproto/server/common.py", line 525, in tcp_handler
    await circuit.recv()
  File "/home/travis/build/NSLS-II/caproto/caproto/server/common.py", line 68, in recv
    await self._on_disconnect()
  File "/home/travis/build/NSLS-II/caproto/caproto/curio/server.py", line 51, in _on_disconnect
    await super()._on_disconnect()
  File "/home/travis/build/NSLS-II/caproto/caproto/server/common.py", line 43, in _on_disconnect
    await sub_spec.db_entry.unsubscribe(queue, sub_spec)
  File "/home/travis/build/NSLS-II/caproto/caproto/_data.py", line 479, in unsubscribe
    self._queues[queue][sub_spec.data_type].remove(sub_spec)
KeyError: SubscriptionSpec(db_entry=<caproto._data.ChannelInteger object at 0x7f9673ae2cf8>, data_type=<ChannelType.LONG: 5>, mask=13, channel_filter=ChannelFilter(ts=None, dbnd=None, arr=None, sync=None))
```