### PR TITLE
API: Make ioc_arg_parser default_prefix default to ''.

### DIFF
--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -935,7 +935,7 @@ class PVGroup(metaclass=PVGroupMeta):
         return value
 
 
-def ioc_arg_parser(*, desc, default_prefix, argv=None, macros=None):
+def ioc_arg_parser(*, desc, default_prefix='', argv=None, macros=None):
     """
     A reusable ArgumentParser for basic example IOCs.
 
@@ -943,7 +943,8 @@ def ioc_arg_parser(*, desc, default_prefix, argv=None, macros=None):
     ----------
     description : string
         Human-friendly description of what that IOC does
-    default_prefix : string
+    default_prefix : string, optional
+        Default ''
     args : list, optional
         Defaults to sys.argv
     macros : dict, optional


### PR DESCRIPTION
As I walked Ke through writing a caproto IOC, I wondered whether we can make
``default_prefix`` optional, just to remove number of things you have to know
to get an IOC up.

I don't feel strongly and defer to others' sense of whether it is a good
idea to let people write an IOC without forcing them to invent a default prefix.
Just a thought.