### PR TITLE
ENH: Channel Access timestamp filter

### DIFF
--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1,7 +1,9 @@
 from collections import defaultdict, deque, namedtuple
 import logging
+import time
 import caproto as ca
 from caproto import apply_arr_filter, get_environment_variables
+from caproto._dbr import DBR_TIME_LONG
 
 
 class DisconnectedCircuit(Exception):
@@ -183,7 +185,6 @@ class VirtualCircuit:
             chan = self.circuit.channels_sid[command.sid]
             db_entry = self.context[chan.name]
             return chan, db_entry
-
         if command is ca.DISCONNECTED:
             raise DisconnectedCircuit()
         elif isinstance(command, ca.VersionRequest):
@@ -211,7 +212,14 @@ class VirtualCircuit:
                 command.data_type, user_address=self.circuit.address)
             # This is a pass-through if arr is None.
             data = apply_arr_filter(chan.channel_filter.arr, data)
-
+            # If the timestamp feature is active swap the timestamp.
+            # Information must copied because not all clients will have the
+            # timestamp filter
+            if chan.channel_filter.ts:
+                now = ca.TimeStamp.from_unix_timestamp(time.time())
+                metadata = DBR_TIME_LONG(status=metadata.status,
+                                         severity=metadata.severity,
+                                         stamp=now)
             notify = isinstance(command, ca.ReadNotifyRequest)
             return [chan.read(data=data, data_type=command.data_type,
                               data_count=len(data), status=1,


### PR DESCRIPTION
First caproto PR 🎉 

This should be fairly simple, but I am pretty unfamiliar with this stuff so please correct me.

## Questions
1. `metadata` is a reference so I do not want to mutate that information so it looked like I was forced to create a new `metadata` object.
2. Am I guaranteed to get a `DBR_TIME_LONG` or do I need to introspect the class and create a new one that way?
```
(caproto) [trendahl@psbuild-rhel7-02  caproto]$ caget -a simple:A
simple:A                       2018-06-12 13:17:21.927088 1  
(caproto) [trendahl@psbuild-rhel7-02  caproto]$ caget -a 'simple:A.{"ts": {}}'
simple:A.{"ts": {}}            2018-06-12 13:33:48.677312 1  
```