### PR TITLE
ENH/FIX: Implement context magic methods on Context.

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -404,6 +404,8 @@ class SharedBroadcaster:
             self.listeners.remove(listener)
         except KeyError:
             pass
+        if not self.listeners:
+            self.disconnect()
 
     def disconnect(self, *, wait=True):
         if self.udp_sock is not None:
@@ -932,6 +934,9 @@ class Context:
                                    idx, total_circuits, circuit)
             self.log.debug('All circuits disconnected')
         finally:
+            # Remove from Broadcaster.
+            self.broadcaster.remove_listener(self)
+
             # clear any state about circuits and search results
             self.log.debug('Clearing circuit managers')
             self.circuit_managers.clear()

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -705,6 +705,12 @@ class Context:
                 f"pvs={len(self.pvs)} "
                 f"idle={len([1 for pv in self.pvs.values() if pv._idle])}>")
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.disconnect(wait=True)
+
     def get_pvs(self, *names, priority=0, connection_state_callback=None,
                 access_rights_callback=None):
         """


### PR DESCRIPTION
Demo that threads clean up on exit:

```py
>>> from caproto.threading.client import Context
>>> with Context() as ctx:
...     pv, = ctx.get_pvs('simple:A')
...     print(pv.read())
... ReadNotifyResponse(data=array([1], dtype=int32),
data_type=<ChannelType.LONG: 5>, data_count=1,
status=CAStatusCode(name='ECA_NORMAL', code=0, code_with_severity=1,
severity=<CASeverity.SUCCESS: 1>, success=1, defunct=False,
description='Normal successful completion'), ioid=1, metadata=None)

>>> import threading
>>> threading.active_count() 1
```

Closes #281 