### PR TITLE
ENH: Accept scalar or str/bytes in write.

### DIFF
--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -489,8 +489,8 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
     Parameters
     ----------
     pv_name : str
-    data : str, int, or float or a list of these
-        Value to write.
+    data : str, int, or float or any Iterable of these
+        Value(s) to write.
     notify : boolean, optional
         Request notification of completion and wait for it. False by default.
     data_type : {'native', 'status', 'time', 'graphic', 'control'} or ChannelType or int ID, optional

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -611,3 +611,13 @@ def test_batch_write_no_callback(context, ioc):
     time.sleep(0.1)
     for pv in pvs:
         assert list(pv.read().data) == [4407]
+
+
+def test_write_accepts_scalar(context, ioc):
+    int_pv, str_pv = context.get_pvs(ioc.pvs['int'], ioc.pvs['str'])
+    for pv in (int_pv, str_pv):
+        pv.wait_for_connection()
+    int_pv.write(17, wait=True)
+    assert list(int_pv.read().data) == [17]
+    str_pv.write('caprotoss', wait=True)
+    assert list(str_pv.read().data) == [b'caprotoss']

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -9,6 +9,7 @@
 # - restart subscriptions
 # - ThreadPoolExecutor for processing user callbacks on read, write, subscribe
 import array
+from collections import Iterable
 import concurrent.futures
 import errno
 import functools
@@ -1438,8 +1439,8 @@ class PV:
 
         Parameters
         ----------
-        data : Iterable
-            values to write
+        data : str, int, or float or any Iterable of these
+            Value(s) to write.
         wait : boolean
             If True (default) block until a matching WriteNotifyResponse is
             received from the server. Raises TimeoutError if that response is
@@ -1460,6 +1461,10 @@ class PV:
             Requested number of values. Default is the channel's native data
             count.
         """
+        if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
+            data = [data]
+        if len(data) and isinstance(data[0], str):
+            data = [val.encode(STR_ENC) for val in data]
         if notify is None:
             notify = (wait or callback is not None)
         ioid = self.circuit_manager._ioid_counter()
@@ -1862,8 +1867,8 @@ class Batch:
         Parameters
         ----------
         pv : PV
-        data : Iterable
-            values to write
+        data : str, int, or float or any Iterable of these
+            Value(s) to write.
         callback : callable
             Expected signature: ``f(response)``
         data_type : {'native', 'status', 'time', 'graphic', 'control'} or ChannelType or int ID, optional
@@ -1873,6 +1878,10 @@ class Batch:
             Requested number of values. Default is the channel's native data
             count.
         """
+        if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
+            data = [data]
+        if len(data) and isinstance(data[0], str):
+            data = [val.encode(STR_ENC) for val in data]
         ioid = pv.circuit_manager._ioid_counter()
         command = pv.channel.write(data=data,
                                    ioid=ioid,


### PR DESCRIPTION
The sync client already does this. (Checked interactively.)

This PR makes the threading client do the same and adds a test.