### PR TITLE
REF: Replace version=13 with version=ca.DEFAULT_PROTOCOL_VERSION.

### DIFF
--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -45,8 +45,9 @@ class VirtualCircuit:
             await curio.spawn(self._receive_loop, daemon=True)
             await curio.spawn(self._command_queue_loop, daemon=True)
             # Send commands that initialize the Circuit.
-            await self.send(ca.VersionRequest(version=13,
-                                              priority=self.circuit.priority))
+            await self.send(ca.VersionRequest(
+                version=ca.DEFAULT_PROTOCOL_VERSION,
+                priority=self.circuit.priority))
             host_name = await socket.gethostname()
             await self.send(ca.HostNameRequest(name=host_name))
             client_name = getpass.getuser()

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -187,7 +187,7 @@ class VirtualCircuit:
         if command is ca.DISCONNECTED:
             raise DisconnectedCircuit()
         elif isinstance(command, ca.VersionRequest):
-            return [ca.VersionResponse(13)]
+            return [ca.VersionResponse(ca.DEFAULT_PROTOCOL_VERSION)]
         elif isinstance(command, ca.CreateChanRequest):
             db_entry = self.context[command.name]
             access = db_entry.check_access(self.client_hostname,
@@ -403,12 +403,15 @@ class Context:
                     # responding with an IP of `None` tells client to get IP
                     # address from the datagram.
                     search_replies.append(
-                        ca.SearchResponse(self.port, None, command.cid, 13)
+                        ca.SearchResponse(self.port, None, command.cid,
+                                          ca.DEFAULT_PROTOCOL_VERSION)
                     )
                 else:
                     if command.reply == ca.DO_REPLY:
                         search_replies.append(
-                            ca.NotFoundResponse(version=13, cid=command.cid)
+                            ca.NotFoundResponse(
+                                version=ca.DEFAULT_PROTOCOL_VERSION,
+                                cid=command.cid)
                         )
                     else:
                         # Not a known PV and no reply required

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -58,8 +58,9 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
         udp_sock.sendto(bytes_to_send, (host, repeater_port))
 
     logger.debug("Searching for '%s'....", pv_name)
-    bytes_to_send = b.send(ca.VersionRequest(0, 13),
-                           ca.SearchRequest(pv_name, 0, 13))
+    bytes_to_send = b.send(
+        ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
+        ca.SearchRequest(pv_name, 0, ca.DEFAULT_PROTOCOL_VERSION))
 
     def send_search():
         for host in ca.get_address_list():
@@ -131,7 +132,9 @@ def make_channel(pv_name, udp_sock, priority, timeout):
 
     try:
         # Initialize our new TCP-based CA connection with a VersionRequest.
-        send(chan.circuit, ca.VersionRequest(priority=priority, version=13))
+        send(chan.circuit, ca.VersionRequest(
+            priority=priority,
+            version=ca.DEFAULT_PROTOCOL_VERSION))
         send(chan.circuit, chan.host_name(socket.gethostname()))
         send(chan.circuit, chan.client_name(getpass.getuser()))
         send(chan.circuit, chan.create())

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -39,7 +39,6 @@ class RepeaterAlreadyRunning(RuntimeError):
 
 def check_clients(clients, skip=None):
     'Check clients by binding to their ports on specific interfaces'
-    # no_op = bytes(caproto.VersionRequest(priority=0, version=0).header)
     sock = None
     for port, host in clients.items():
         addr = (host, port)

--- a/caproto/tests/test_core.py
+++ b/caproto/tests/test_core.py
@@ -83,7 +83,8 @@ def test_circuit_properties():
 
     # VersionRequest priority must match prio set above.
     with pytest.raises(ca.LocalProtocolError):
-        circuit.send(ca.VersionRequest(version=13, priority=2))
+        circuit.send(ca.VersionRequest(
+            version=ca.DEFAULT_PROTOCOL_VERSION, priority=2))
 
 
 def test_broadcaster():
@@ -159,10 +160,12 @@ def test_empty_datagram():
 
 
 def test_extract_address():
-    old_style = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0, version=13)
+    old_style = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0,
+                                  version=ca.DEFAULT_PROTOCOL_VERSION)
     old_style.header.parameter1 = 0xffffffff
     old_style.sender_address = ('5.6.7.8', 6666)
-    new_style = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0, version=13)
+    new_style = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0,
+                                  version=ca.DEFAULT_PROTOCOL_VERSION)
     ca.extract_address(old_style) == '1.2.3.4'
     ca.extract_address(new_style) == '5.6.7.8'
 
@@ -175,7 +178,8 @@ def test_register_convenience_method():
 def test_broadcaster_checks():
     b = ca.Broadcaster(ca.CLIENT)
     with pytest.raises(ca.LocalProtocolError):
-        b.send(ca.SearchRequest(name='LIRR', cid=0, version=13))
+        b.send(ca.SearchRequest(name='LIRR', cid=0,
+                                version=ca.DEFAULT_PROTOCOL_VERSION))
 
     b.send(ca.RepeaterRegisterRequest('1.2.3.4'))
     res = ca.RepeaterConfirmResponse('5.6.7.8')
@@ -183,19 +187,22 @@ def test_broadcaster_checks():
     assert commands[0] == res
     b.process_commands(commands)
 
-    req = ca.SearchRequest(name='LIRR', cid=0, version=13)
+    req = ca.SearchRequest(name='LIRR', cid=0,
+                           version=ca.DEFAULT_PROTOCOL_VERSION)
     with pytest.raises(ca.LocalProtocolError):
         b.send(req)
-    b.send(ca.VersionRequest(priority=0, version=13), req)
+    b.send(ca.VersionRequest(priority=0,
+                             version=ca.DEFAULT_PROTOCOL_VERSION), req)
 
-    res = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0, version=13)
+    res = ca.SearchResponse(port=6666, ip='1.2.3.4', cid=0,
+                            version=ca.DEFAULT_PROTOCOL_VERSION)
     addr = ('1.2.3.4', 6666)
     commands = b.recv(bytes(res), addr)
     # see changes to _broadcaster.py.  Apparently rsrv does not always conform
     # to the protocol and include a version response before search responsesq
     # with pytest.raises(ca.RemoteProtocolError):
     #     b.process_commands(commands)
-    # commands = b.recv(bytes(ca.VersionResponse(version=13)) + bytes(res), addr)
+    # commands = b.recv(bytes(ca.VersionResponse(version=ca.DEFAULT_PROTOCOL_VERSION)) + bytes(res), addr)
     b.process_commands(commands)  # this gets both
 
 

--- a/caproto/tests/test_nonet.py
+++ b/caproto/tests/test_nonet.py
@@ -61,15 +61,16 @@ def test_nonet():
     # Search for pv1.
     # CA requires us to send a VersionRequest and a SearchRequest bundled into
     # one datagram.
-    bytes_to_send = cli_b.send(ca.VersionRequest(0, 13),
-                               ca.SearchRequest(pv1, 0, 13))
+    bytes_to_send = cli_b.send(ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
+                               ca.SearchRequest(pv1, 0,
+                                                ca.DEFAULT_PROTOCOL_VERSION))
 
     commands = srv_b.recv(bytes_to_send, cli_addr)
     srv_b.process_commands(commands)
     ver_req, search_req = commands
-    bytes_to_send = srv_b.send(ca.VersionResponse(13),
-                               ca.SearchResponse(5064, None,
-                                                 search_req.cid, 13))
+    bytes_to_send = srv_b.send(
+        ca.VersionResponse(ca.DEFAULT_PROTOCOL_VERSION),
+        ca.SearchResponse(5064, None, search_req.cid, ca.DEFAULT_PROTOCOL_VERSION))
 
     # Receive a VersionResponse and SearchResponse.
     commands = iter(cli_b.recv(bytes_to_send, cli_addr))
@@ -90,16 +91,17 @@ def test_nonet():
     srv_circuit = ca.VirtualCircuit(our_role=ca.SERVER,
                                     address=address, priority=None)
 
-    cli_send(chan1.circuit, ca.VersionRequest(priority=0, version=13))
+    cli_send(chan1.circuit, ca.VersionRequest(priority=0,
+                                              version=ca.DEFAULT_PROTOCOL_VERSION))
 
     srv_recv(srv_circuit)
 
-    srv_send(srv_circuit, ca.VersionResponse(version=13))
+    srv_send(srv_circuit, ca.VersionResponse(version=ca.DEFAULT_PROTOCOL_VERSION))
     cli_recv(chan1.circuit)
     cli_send(chan1.circuit, ca.HostNameRequest('localhost'))
     cli_send(chan1.circuit, ca.ClientNameRequest('username'))
     cli_send(chan1.circuit, ca.CreateChanRequest(name=pv1, cid=chan1.cid,
-                                                 version=13))
+                                                 version=ca.DEFAULT_PROTOCOL_VERSION))
     assert chan1.states[ca.CLIENT] is ca.AWAIT_CREATE_CHAN_RESPONSE
     assert chan1.states[ca.SERVER] is ca.SEND_CREATE_CHAN_RESPONSE
 

--- a/caproto/tests/test_serialization.py
+++ b/caproto/tests/test_serialization.py
@@ -309,7 +309,8 @@ def test_bytelen():
 
 def test_overlong_strings():
     with pytest.raises(ca.CaprotoValueError):
-        ca.SearchRequest(name='a' * (ca.MAX_RECORD_LENGTH + 1), cid=0, version=13)
+        ca.SearchRequest(name='a' * (ca.MAX_RECORD_LENGTH + 1), cid=0,
+                         version=ca.DEFAULT_PROTOCOL_VERSION)
 
 
 skip_ext_headers = [

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -611,7 +611,8 @@ class SharedBroadcaster:
             # filter to just things that need to go out
             def _construct_search_requests(items):
                 for search_id, it in items:
-                    yield ca.SearchRequest(it[0], search_id, 13)
+                    yield ca.SearchRequest(it[0], search_id,
+                                           ca.DEFAULT_PROTOCOL_VERSION)
                     it[-1] = t
 
             with self._search_lock:
@@ -628,7 +629,9 @@ class SharedBroadcaster:
 
             for batch in batch_requests(requests,
                                         SEARCH_MAX_DATAGRAM_BYTES):
-                self.send(ca.EPICS_CA1_PORT, ca.VersionRequest(0, 13), *batch)
+                self.send(ca.EPICS_CA1_PORT,
+                          ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
+                          *batch)
 
             wait_time = max(0, RETRY_SEARCHES_PERIOD - (time.monotonic() - t))
             self._search_now.wait(wait_time)
@@ -1007,7 +1010,8 @@ class VirtualCircuitManager:
         if self.circuit.states[ca.SERVER] is ca.IDLE:
             self.socket = socket.create_connection(self.circuit.address)
             self.selector.add_socket(self.socket, self)
-            self.send(ca.VersionRequest(self.circuit.priority, 13),
+            self.send(ca.VersionRequest(self.circuit.priority,
+                                        ca.DEFAULT_PROTOCOL_VERSION),
                       ca.HostNameRequest(self.context.host_name),
                       ca.ClientNameRequest(self.context.client_name))
         else:

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -68,7 +68,7 @@ class VirtualCircuit:
         self.nursery.start_soon(self._receive_loop)
         self.nursery.start_soon(self._command_queue_loop)
         # Send commands that initialize the Circuit.
-        await self.send(ca.VersionRequest(version=13,
+        await self.send(ca.VersionRequest(version=ca.DEFAULT_PROTOCOL_VERSION,
                                           priority=self.circuit.priority))
         host_name = socket.gethostname()
         await self.send(ca.HostNameRequest(name=host_name))
@@ -422,10 +422,12 @@ class SharedBroadcaster:
 
         while needs_search:
             self.log.debug('Searching for %r PVs....', len(needs_search))
-            requests = (ca.SearchRequest(name, search_id, 13)
+            requests = (ca.SearchRequest(name, search_id,
+                                         ca.DEFAULT_PROTOCOL_VERSION)
                         for search_id, name in needs_search)
             for batch in batch_requests(requests, SEARCH_MAX_DATAGRAM_BYTES):
-                await self.send(ca.EPICS_CA1_PORT, ca.VersionRequest(0, 13),
+                await self.send(ca.EPICS_CA1_PORT,
+                                ca.VersionRequest(0, ca.DEFAULT_PROTOCOL_VERSION),
                                 *batch)
 
             with trio.move_on_after(1):


### PR DESCRIPTION
Closes #302

``version=13`` has been scrubbed from the code and tests. It still
appears in some docs example, which I think is good/fine.