### PR TITLE
FIX: Enforce quotas per subscription under high load.

### DIFF
--- a/caproto/_commands.py
+++ b/caproto/_commands.py
@@ -464,6 +464,9 @@ class Message(metaclass=_MetaDirectionalMessage):
     def __eq__(self, other):
         return bytes(self) == bytes(other)
 
+    def __hash__(self):
+        return hash(bytes(self))
+
     def __ne__(self, other):
         return bytes(self) != bytes(other)
 
@@ -958,7 +961,7 @@ class EventAddResponse(Message):
 
         Echoing the :data:`subscriptionid` in the :class:`EventAddRequest`
     """
-    __slots__ = ()
+    __slots__ = ('__weakref__',)
     ID = 1
     HAS_PAYLOAD = True
 

--- a/caproto/_constants.py
+++ b/caproto/_constants.py
@@ -30,6 +30,10 @@ SEARCH_MAX_DATAGRAM_BYTES = 9216
 # https://epics.anl.gov/docs/CAproto.html#secVCUnresponsive
 SERVER_MIA_PRESUMED_DEAD = 60  # seconds
 
+MAX_TOTAL_SUBSCRIPTION_BACKLOG = 1000  # total per circuit not per subscription
+MAX_SUBSCRIPTION_BACKLOG = 100  # per subscription
+MAX_COMMAND_BACKLOG = 1000
+
 
 DO_REPLY = 10
 NO_REPLY = 5

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -71,10 +71,24 @@ class VirtualCircuit(_VirtualCircuit):
 
         self._raw_client = client
         super().__init__(circuit, SockWrapper(loop, client), context)
-        self.command_queue = asyncio.Queue()
-        self.new_command_condition = asyncio.Condition()
+        self.command_queue = asyncio.Queue(ca.MAX_COMMAND_BACKLOG,
+                                           loop=self.loop)
+        self.new_command_condition = asyncio.Condition(loop=self.loop)
+        self.events_on = asyncio.Event(loop=self.loop)
+        self.subscription_queue = asyncio.Queue(
+            ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG, loop=self.loop)
         self._cq_task = None
+        self._sq_task = None
         self._write_tasks = ()
+
+    async def get_from_sub_queue_with_timeout(self, timeout):
+        # Timeouts work very differently between our server implementations,
+        # so we do this little stub in its own method.
+        fut = asyncio.ensure_future(self.subscription_queue.get())
+        try:
+            return await asyncio.wait_for(fut, timeout, loop=self.loop)
+        except asyncio.TimeoutError:
+            return None
 
     async def send(self, *commands):
         if self.connected:
@@ -84,6 +98,7 @@ class VirtualCircuit(_VirtualCircuit):
 
     async def run(self):
         self._cq_task = self.loop.create_task(self.command_queue_loop())
+        self._sq_task = self.loop.create_task(self.subscription_queue_loop())
 
     async def _start_write_task(self, handle_write):
         tsk = self.loop.create_task(handle_write())
@@ -99,6 +114,8 @@ class VirtualCircuit(_VirtualCircuit):
         self._raw_client.close()
         if self._cq_task is not None:
             self._cq_task.cancel()
+        if self._sq_task is not None:
+            self._sq_task.cancel()
 
 
 class Context(_Context):
@@ -231,9 +248,9 @@ class Context(_Context):
         except asyncio.CancelledError:
             self.log.info('Server task cancelled. Will shut down.')
             udp_sock.close()
-            all_tasks = (tasks + self._server_tasks + [c._cq_task
-                                                       for c in self.circuits
-                                                       if c._cq_task is not None] +
+            all_tasks = (tasks + self._server_tasks +
+                         [c._cq_task for c in self.circuits if c._cq_task is not None] +
+                         [c._sq_task for c in self.circuits if c._sq_task is not None] +
                          [t for c in self.circuits for t in c._write_tasks] +
                          list(self.p._tasks))
             for t in all_tasks:

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -71,6 +71,7 @@ class VirtualCircuit(_VirtualCircuit):
 
         self._raw_client = client
         super().__init__(circuit, SockWrapper(loop, client), context)
+        self.QueueFull = asyncio.QueueFull
         self.command_queue = asyncio.Queue(ca.MAX_COMMAND_BACKLOG,
                                            loop=self.loop)
         self.new_command_condition = asyncio.Condition(loop=self.loop)

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument('pv_names', type=str, nargs='+',
                         help="PV (channel) name(s) separated by spaces")
     parser.add_argument('--verbose', '-v', action='count',
-                        help="Verbose mode. (Use -vvv for more.)")
+                        help="Show more log messages. (Use -vvv for even more.)")
     fmt_group.add_argument('--format', type=str,
                            help=("Python format string. Available tokens are "
                                  "{pv_name} and {response}. Additionally, if "

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -33,7 +33,7 @@ def main():
                                  "like {timestamp:%%Y-%%m-%%d %%H:%%M:%%S} are"
                                  " supported."))
     parser.add_argument('--verbose', '-v', action='count',
-                        help="Show DEBUG log messages.")
+                        help="Show more log messages. (Use -vvv for even more.)")
     exit_group.add_argument('--duration', type=float, default=None,
                             help=("Maximum number seconds to run before "
                                   "exiting. Runs indefinitely by default."))

--- a/caproto/commandline/put.py
+++ b/caproto/commandline/put.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument('data', type=str,
                         help="Value or values to write.")
     parser.add_argument('--verbose', '-v', action='count',
-                        help="Show DEBUG log messages.")
+                        help="Show more log messages. (Use -vvv for even more.)")
     fmt_group.add_argument('--format', type=str,
                            help=("Python format string. Available tokens are "
                                  "{pv_name}, {response} and {which} (Old/New)."

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -41,12 +41,15 @@ class VirtualCircuit(_VirtualCircuit):
 
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
-        self.command_queue = curio.Queue()
+        self.command_queue = curio.Queue(ca.MAX_COMMAND_BACKLOG)
         self.new_command_condition = curio.Condition()
         self.pending_tasks = curio.TaskGroup()
+        self.events_on = curio.Event()
+        self.subscription_queue = curio.Queue(ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG)
 
     async def run(self):
         await self.pending_tasks.spawn(self.command_queue_loop())
+        await self.pending_tasks.spawn(self.subscription_queue_loop())
 
     async def _on_disconnect(self):
         """Executed when disconnection detected"""
@@ -60,6 +63,12 @@ class VirtualCircuit(_VirtualCircuit):
     async def _wake_new_command(self):
         async with self.new_command_condition:
             await self.new_command_condition.notify_all()
+
+    async def get_from_sub_queue_with_timeout(self, timeout):
+        # Timeouts work very differently between our server implementations,
+        # so we do this little stub in its own method.
+        # Returns weakref(EventAddResponse) or None
+        return await curio.ignore_after(timeout, self.subscription_queue.get)
 
 
 class Context(_Context):

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -29,6 +29,18 @@ class UniversalQueue(curio.UniversalQueue):
         return await super().get()
 
 
+class QueueFull(Exception):
+    ...
+
+
+# Curio queues just block if they are full. We want one that raises.
+class QueueWithFullError(curio.Queue):
+    async def put(self, item):
+        if self.full():
+            raise QueueFull
+        await super().put(item)
+
+
 class CurioAsyncLayer(AsyncLibraryLayer):
     name = 'curio'
     ThreadsafeQueue = UniversalQueue
@@ -41,11 +53,13 @@ class VirtualCircuit(_VirtualCircuit):
 
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
-        self.command_queue = curio.Queue(ca.MAX_COMMAND_BACKLOG)
+        self.QueueFull = QueueFull
+        self.command_queue = QueueWithFullError(ca.MAX_COMMAND_BACKLOG)
         self.new_command_condition = curio.Condition()
         self.pending_tasks = curio.TaskGroup()
         self.events_on = curio.Event()
-        self.subscription_queue = curio.Queue(ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG)
+        self.subscription_queue = QueueWithFullError(
+            ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG)
 
     async def run(self):
         await self.pending_tasks.spawn(self.command_queue_loop())

--- a/caproto/ioc_examples/random_walk.py
+++ b/caproto/ioc_examples/random_walk.py
@@ -13,7 +13,7 @@ class RandomWalkIOC(PVGroup):
         while True:
             # compute next value
             x, = self.x.value
-            x += random.random()
+            x += 2 * random.random() - 1
 
             # update the ChannelData instance and notify any subscribers
             await instance.write(value=[x])

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -301,9 +301,10 @@ class VirtualCircuit:
                     self.log.warning("High EventAddResponse load. Dropped "
                                      "%d responses.", num_expired)
                 if len_commands > 1:
-                    self.log.info("High EventAddResponse load. Batch size: "
-                                  "%d commands (%d bytes).",
-                                  len_commands, commands_bytes)
+                    self.log.info(
+                        "High EventAddResponse load. Batching with %f-second "
+                        "latency. Batch size: %d commands (%d bytes).",
+                        HIGH_LOAD_TIMEOUT, len_commands, commands_bytes)
                 await self.send(*commands)
             except DisconnectedCircuit:
                 await self._on_disconnect()

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -288,6 +288,12 @@ class VirtualCircuit:
                     # Accumulate commands into a batch.
                     commands.append(command)
                     commands_bytes += len(command)
+                    if len(commands) == 1:
+                        # Set a dealine by which will must send this oldest
+                        # command in the batch, effecitvely a limit of latency.
+                        deadline = time.monotonic() + HIGH_LOAD_TIMEOUT
+                    elif deadline < time.monotonic():
+                        send_now = True
                     # Send the batch if we are in low-latency / slow producer
                     # mode (send_now=True) or the batch has reached max size.
                     # But be sure _not_ to send it if it is empty (because all

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -1,5 +1,6 @@
 from collections import defaultdict, deque, namedtuple, ChainMap, Iterable
 import copy
+import itertools
 import logging
 import sys
 import time
@@ -56,9 +57,8 @@ class OrderedBoundedSet:
     def update(self, items):
         self._data.update(dict.fromkeys(items))
         overage = len(self) - self.maxlen
-        if overage > 0:
-            for _ in range(overage):
-                self.pop()
+        for item in itertools.islice(iter(self._data), overage):
+            self._data.pop(item)
 
     def pop(self):
         item = next(iter(self._data))

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -3,10 +3,23 @@ import copy
 import logging
 import sys
 import time
+import weakref
 import caproto as ca
 from caproto import (apply_arr_filter, get_environment_variables,
                      RemoteProtocolError)
 from .._dbr import SubscriptionType
+
+
+# ** Tuning this parameters will affect the servers' performance **
+# ** under high load. **
+# If the queue of subscriptions to has a new update ready within this timeout,
+# we consider ourselves under high load and trade accept some latency for some
+# efficiency.
+HIGH_LOAD_TIMEOUT = 0.01
+# When a batch of subscription updates has this many bytes or more, send it.
+# Decrease this number to improve latency under load; increase it to improve
+# efficiency.
+SUB_BATCH_THRESH = 2**16
 
 
 class DisconnectedCircuit(Exception):
@@ -24,6 +37,26 @@ SubscriptionSpec = namedtuple('SubscriptionSpec', ('db_entry', 'data_type',
 host_endian = ('>' if sys.byteorder == 'big' else '<')
 
 
+class BoundedSet(set):
+    def __init__(self, items=None, *, maxlen):
+        if items is None:
+            items = ()
+        super().__init__(items)
+        self.maxlen = maxlen
+
+    def add(self, item):
+        super().add(item)
+        if len(self) > self.maxlen:
+            self.pop()
+
+    def update(self, items):
+        super().update(items)
+        overage = len(self) - self.maxlen
+        if overage > 0:
+            for _ in range(overage):
+                self.pop()
+
+
 class VirtualCircuit:
     def __init__(self, circuit, client, context):
         self.connected = True
@@ -34,6 +67,14 @@ class VirtualCircuit:
         self.client_hostname = None
         self.client_username = None
         self.subscriptions = defaultdict(deque)
+        self.unexpired_updates = defaultdict(
+            lambda: BoundedSet(maxlen=ca.MAX_SUBSCRIPTION_BACKLOG))
+        # Subclasses are expected to define:
+        # self.command_queue = ...
+        # self.new_command_condition = ...
+        # self.subscription_queue = ...
+        # self.get_from_sub_queue_with_timeout = ...
+        # self.events_on = ...
 
     async def _on_disconnect(self):
         """Executed when disconnection detected"""
@@ -162,6 +203,82 @@ class VirtualCircuit:
                     await self.send(response_command)
 
             await self._wake_new_command()
+
+    async def subscription_queue_loop(self):
+        maybe_coroutine = self.events_on.set()
+        # The curio backend makes this an awaitable thing.
+        if maybe_coroutine is not None:
+            await maybe_coroutine
+        commands = deque()
+        commands_bytes = 0
+        while True:
+            send_now = False
+            try:
+                # We are covering two regimes of operation here. In the "slow
+                # producer" regime, the server is only occasionally sending
+                # updates, and it should optimize for low latency. In the "fast
+                # producer" regime, the server is flooded with updates that it
+                # needs to get out onto the wire as efficiently as possible,
+                # and it should sacrifice some latency in order to batch
+                # requests efficiently.
+                while True:
+                    ref = await self.get_from_sub_queue_with_timeout(HIGH_LOAD_TIMEOUT)
+                    if ref is None:
+                        # We have caught up with the producer. Stop batching,
+                        # and optimize for low latency.
+                        send_now = True
+                        if commands:
+                            # We have accumulated commands while previously in
+                            # the "fast producer" regime. Short-circuit and
+                            # send them.
+                            break
+
+                        # Block here until we have something to send...
+                        ref = await self.subscription_queue.get()
+
+                    command = ref()
+                    if command is None:
+                        # Quota for this subscription has been exceeded.  This
+                        # client is a slow consumer. To avoid letting it get
+                        # behind, drop this message on the floor and move on.
+                        # We are dropping "old news" in favor of prioritizing
+                        # getting the "latest news" out. Note that the
+                        # reference implementation in epics-base, rsrv, does
+                        # the opposite: it drops the new news and sends the old
+                        # news. Jeff Hill has stated clearly that this should
+                        # be considered an implementation detail, not part of
+                        # the specification. The C++ implementation can save
+                        # some memory by discarding the latest updates, but it
+                        # is more useful to discard the oldest updates. Python
+                        # might as well do the more useful thing, given that
+                        # its baseline memory usage is high.
+                        continue
+                    self.unexpired_updates[command.subscriptionid].discard(command)
+                    # Accumulate commands into a batch.
+                    commands.append(command)
+                    commands_bytes += len(command)
+                    # Send the batch if we are in low-latency / slow producer
+                    # mode (send_now=True) or the batch has reached max size.
+                    # But be sure _not_ to send it if it is empty (because all
+                    # the would-be contents were expired.)
+                    if commands and (send_now or commands_bytes > SUB_BATCH_THRESH):
+                        break
+            except self.TaskCancelled:
+                break
+            try:
+                len_commands = len(commands)
+                if len_commands > 1:
+                    self.log.info("High EventAddResponse load. Batch size: "
+                                  "%d commands (%d bytes).",
+                                  len_commands, commands_bytes)
+                await self.send(*commands)
+            except DisconnectedCircuit:
+                await self._on_disconnect()
+                self.circuit.disconnect()
+                await self.context.circuit_disconnected(self)
+                break
+            commands.clear()
+            commands_bytes = 0
 
     async def _cull_subscriptions(self, db_entry, func):
         # Iterate through each Subscription, passing each one to func(sub).
@@ -338,6 +455,21 @@ class VirtualCircuit:
             return [chan.unsubscribe(command.subscriptionid,
                                      data_type=command.data_type,
                                      data_count=data_count)]
+        elif isinstance(command, ca.EventsOnRequest):
+            maybe_coroutine = self.events_on.set()
+            # The curio backend makes this an awaitable thing.
+            if maybe_coroutine is not None:
+                await maybe_coroutine
+        elif isinstance(command, ca.EventsOffRequest):
+            # The client has signaled that it does not think it will be able to
+            # catch up to the backlog. Clear all updates queued to be sent...
+            self.unexpired_updates.clear()
+            # ...and tell the Context that any future updates from ChannelData
+            # should not be added to this circuit's queue until further notice.
+            maybe_coroutine = self.events_on.clear()
+            # The curio backend makes this an awaitable thing.
+            if maybe_coroutine is not None:
+                await maybe_coroutine
         elif isinstance(command, ca.ClearChannelRequest):
             chan, db_entry = get_db_entry()
             await self._cull_subscriptions(
@@ -491,6 +623,7 @@ class Context:
             # This queue receives updates that match the db_entry, data_type
             # and mask ("subscription spec") of one or more subscriptions.
             sub_specs, metadata, values, flags = await self.subscription_queue.get()
+
             subs = []
             for sub_spec in sub_specs:
                 subs.extend(self.subscriptions[sub_spec])
@@ -498,6 +631,13 @@ class Context:
             # We have to make a new response for each channel because each may
             # have a different requested data_count.
             for sub in subs:
+                circuit = sub.circuit
+                # If this circuit has been sent EventsOff by the client, do not
+                # queue any updates until the client sends EventsOn to signal
+                # that it has caught up.
+                if not circuit.events_on.is_set():
+                    continue
+
                 s_flags = flags
                 chan = sub.channel
 
@@ -567,10 +707,22 @@ class Context:
                         # Stash this and then send it.
                         self.last_sync_edge_update[sub][sync.s][sync.m] = command
 
-                # Check that the Channel did not close at some point after
-                # this update started its flight.
-                if chan.states[ca.SERVER] is ca.CONNECTED:
-                    await sub.circuit.send(command)
+                # This update will be put at the back of the line of updates to
+                # be sent.
+                #
+                # If len(unexpired_updates) == SUBSCRIPTION_BACKLOG_QUOTA, then
+                # the command at the front of the line will be kicked out. It
+                # is not literally removed from the queue but whenever it
+                # reaches the front of the line it will dropped on the floor
+                # instead of sent.
+
+                # This is a deque with a maxlen, containing only commands for
+                # this particular subscription.
+                circuit.unexpired_updates[sub.subscriptionid].add(command)
+
+                # This is a queue with the commands from _all_ subscriptions on
+                # this circuit.
+                await circuit.subscription_queue.put(weakref.ref(command))
 
     async def broadcast_beacon_loop(self):
         self.log.debug('Will send beacons to %r',

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -762,8 +762,11 @@ class Context:
                     await circuit.subscription_queue.put(weakref.ref(command))
                 except self.QueueFull:
                     # We have hit the overall max for subscription backlog.
-                    # TODO -- Warn. Maybe drain the queue to catch up?
-                    pass
+                    circuit.log.warning(
+                        "Critically high EventAddResponse load. Dropping all "
+                        "queued responses on this circuit.")
+                    circuit.subscription_queue.clear()
+                    circuit.unexpired_updates.clear()
 
     async def broadcast_beacon_loop(self):
         self.log.debug('Will send beacons to %r',

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -336,7 +336,7 @@ class VirtualCircuit:
                     to_remove.append((sub_spec, sub))
         for sub_spec, sub in to_remove:
             self.subscriptions[sub_spec].remove(sub)
-            del self.most_recent_updates[sub.subscriptionid]
+            self.most_recent_updates.pop(sub.subscriptionid, None)
             self.context.subscriptions[sub_spec].remove(sub)
             self.context.last_dead_band.pop(sub, None)
             self.context.last_sync_edge_update.pop(sub, None)

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -716,14 +716,15 @@ class Context:
                 # This update will be put at the back of the line of updates to
                 # be sent.
                 #
-                # If len(unexpired_updates) == SUBSCRIPTION_BACKLOG_QUOTA, then
-                # the command at the front of the line will be kicked out. It
-                # is not literally removed from the queue but whenever it
+                # If len(unexpired_updates[id]) == SUBSCRIPTION_BACKLOG_QUOTA,
+                # then the command at the front of the line will be kicked out.
+                # It is not literally removed from the queue but whenever it
                 # reaches the front of the line it will dropped on the floor
-                # instead of sent.
+                # instead of sent. This effectively prioritizes sending the
+                # client "new news" instead of "old news".
 
-                # This is a deque with a maxlen, containing only commands for
-                # this particular subscription.
+                # This is a BoundedSet, a set with a maxlen, containing only
+                # commands for this particular subscription.
                 circuit.unexpired_updates[sub.subscriptionid].add(command)
 
                 # This is a queue with the commands from _all_ subscriptions on

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1111,10 +1111,8 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
     group.add_argument('-q', '--quiet', action='store_true',
                        help=("Suppress INFO log messages. "
                              "(Still show WARNING or higher.)"))
-    group.add_argument('-v', '--verbose', action='store_true',
-                       help="Verbose mode. (Use -vvv for more.)")
-    group.add_argument('-vvv', action='store_true',
-                       help=argparse.SUPPRESS)
+    group.add_argument('-v', '--verbose', action='count',
+                        help="Show more log messages. (Use -vvv for even more.)")
     parser.add_argument('--list-pvs', action='store_true',
                         help="At startup, log the list of PV names served.")
     choices = tuple(supported_async_libs or ('asyncio', 'curio', 'trio'))
@@ -1154,16 +1152,16 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
         run_options : dict
             kwargs to be handed to run
         """
-        if args.vvv:
+        if args.verbose > 1:
             logging.getLogger('caproto').setLevel('DEBUG')
         else:
             if args.verbose:
-                level = 'DEBUG'
+                logging.getLogger('caproto.ctx').setLevel('DEBUG')
+                logging.getLogger('caproto.circ').setLevel('INFO')
             elif args.quiet:
-                level = 'WARNING'
+                logging.getLogger('caproto').setLevel('WARNING')
             else:
-                level = 'INFO'
-            logging.getLogger('caproto.ctx').setLevel(level)
+                logging.getLogger('caproto.ctx').setLevel('INFO')
 
         return ({'prefix': args.prefix,
                  'macros': {key: getattr(args, key) for key in macros}},

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1112,7 +1112,7 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
                        help=("Suppress INFO log messages. "
                              "(Still show WARNING or higher.)"))
     group.add_argument('-v', '--verbose', action='count',
-                        help="Show more log messages. (Use -vvv for even more.)")
+                       help="Show more log messages. (Use -vvv for even more.)")
     parser.add_argument('--list-pvs', action='store_true',
                         help="At startup, log the list of PV names served.")
     choices = tuple(supported_async_libs or ('asyncio', 'curio', 'trio'))

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -1152,16 +1152,16 @@ def template_arg_parser(*, desc, default_prefix, argv=None, macros=None,
         run_options : dict
             kwargs to be handed to run
         """
-        if args.verbose > 1:
-            logging.getLogger('caproto').setLevel('DEBUG')
-        else:
-            if args.verbose:
+        if args.verbose:
+            if args.verbose > 1:
+                logging.getLogger('caproto').setLevel('DEBUG')
+            else:
                 logging.getLogger('caproto.ctx').setLevel('DEBUG')
                 logging.getLogger('caproto.circ').setLevel('INFO')
-            elif args.quiet:
-                logging.getLogger('caproto').setLevel('WARNING')
-            else:
-                logging.getLogger('caproto.ctx').setLevel('INFO')
+        elif args.quiet:
+            logging.getLogger('caproto').setLevel('WARNING')
+        else:
+            logging.getLogger('caproto.ctx').setLevel('INFO')
 
         return ({'prefix': args.prefix,
                  'macros': {key: getattr(args, key) for key in macros}},

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -651,7 +651,6 @@ def test_events_off_and_on(ioc, context):
 
     assert monitor_values[1:] == [1, 2, 3]
 
-
     pv.circuit_manager.events_off()
     time.sleep(0.2)  # Wait for EventsOffRequest to be processed.
     pv.write((4, ), wait=True)

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -622,3 +622,55 @@ def test_write_accepts_scalar(context, ioc):
     assert list(int_pv.read().data) == [17]
     str_pv.write('caprotoss', wait=True)
     assert list(str_pv.read().data) == [b'caprotoss']
+
+
+def test_events_off_and_on(ioc, context):
+    pv, = context.get_pvs(ioc.pvs['int'])
+    pv.wait_for_connection(timeout=10)
+
+    monitor_values = []
+
+    def callback(command, **kwargs):
+        assert isinstance(command, ca.EventAddResponse)
+        monitor_values.append(command.data[0])
+
+    sub = pv.subscribe()
+    sub.add_callback(callback)
+    time.sleep(0.2)  # Wait for EventAddRequest to be sent and processed.
+    pv.write((1, ), wait=True)
+    pv.write((2, ), wait=True)
+    pv.write((3, ), wait=True)
+    time.sleep(0.2)  # Wait for the last update to be processed.
+
+    for i in range(3):
+        if pv.read().data[0] == 3:
+            time.sleep(0.2)
+            break
+        else:
+            time.sleep(0.2)
+
+    assert monitor_values[1:] == [1, 2, 3]
+
+
+    pv.circuit_manager.events_off()
+    time.sleep(0.2)  # Wait for EventsOffRequest to be processed.
+    pv.write((4, ), wait=True)
+    pv.write((5, ), wait=True)
+    pv.write((6, ), wait=True)
+    time.sleep(0.2)  # Wait for the last update to be processed.
+    pv.circuit_manager.events_on()
+    time.sleep(0.2)  # Wait for EventsOnRequest to be processed.
+    # The last update, 6, should be sent at this time.
+
+    pv.write((7, ), wait=True)
+    pv.write((8, ), wait=True)
+    pv.write((9, ), wait=True)
+
+    for i in range(3):
+        if pv.read().data[0] == 7:
+            time.sleep(0.2)
+            break
+        else:
+            time.sleep(0.2)
+
+    assert monitor_values[1:] == [1, 2, 3, 6, 7, 8, 9]

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1072,6 +1072,21 @@ class VirtualCircuitManager:
             return ca.DISCONNECTED
         return num_bytes_needed
 
+    def events_off(self):
+        """
+        Suspend updates to all subscriptions on this circuit.
+
+        This may be useful if the server produces updates faster than the
+        client can processs them.
+        """
+        self.send(ca.EventsOffRequest())
+
+    def events_on(self):
+        """
+        Reactive updates to all subscriptions on this circuit.
+        """
+        self.send(ca.EventsOnRequest())
+
     def _process_command(self, command):
         try:
             self.circuit.process_command(command)

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -50,15 +50,28 @@ class VirtualCircuit(_VirtualCircuit):
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
         self.nursery = context.nursery
-        self.command_queue = trio.Queue(1000)
+        self.command_queue = trio.Queue(ca.MAX_COMMAND_BACKLOG)
         self.new_command_condition = trio.Condition()
+        self.subscription_queue = trio.Queue(ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG)
+        self.events_on = trio.Event()
 
     async def run(self):
         await self.nursery.start(self.command_queue_loop)
+        await self.nursery.start(self.subscription_queue_loop)
 
     async def command_queue_loop(self, task_status):
         task_status.started()
         await super().command_queue_loop()
+
+    async def subscription_queue_loop(self, task_status):
+        task_status.started()
+        await super().subscription_queue_loop()
+
+    async def get_from_sub_queue_with_timeout(self, timeout):
+        # Timeouts work very differently between our server implementations,
+        # so we do this little stub in its own method.
+        with trio.move_on_after(timeout):
+            return await self.subscription_queue.get()
 
     async def _on_disconnect(self):
         """Executed when disconnection detected"""

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -50,6 +50,7 @@ class VirtualCircuit(_VirtualCircuit):
     def __init__(self, circuit, client, context):
         super().__init__(circuit, client, context)
         self.nursery = context.nursery
+        self.QueueFull = trio.WouldBlock
         self.command_queue = trio.Queue(ca.MAX_COMMAND_BACKLOG)
         self.new_command_condition = trio.Condition()
         self.subscription_queue = trio.Queue(ca.MAX_TOTAL_SUBSCRIPTION_BACKLOG)

--- a/doc/source/protocol-compliance.rst
+++ b/doc/source/protocol-compliance.rst
@@ -67,10 +67,17 @@ Supported:
 * Channel Access filters (arr, dbnd, ts, sync) including their "shorthand"
   syntax
 * DBE mask specification
+* Enforces quota per subscription to avoid one prolific subscription (or slow
+  client) from drowning out others
+* Respects ``EventsOn`` and ``EventsOff``
+* Under high load (with many subscription updates queued up to send) batches
+  subscriptions into blocks, trading a little latency for efficiency. Under low
+  load, prioritizes low latency.
 
 TO DO:
 
-* Enforcing quotas per subscription to avoid one prolific subscription (or slow
-  client) from drowning out others
-* Respecting ``EventsOn`` and ``EventsOff``
 * Deprecated mask specification (low, high, to)
+* Circuit "priority" is ignored by the server. Python does not implement
+  "thread priority" or any analogue of it for task scheduling. Caproto could
+  roll its own mechanism for this, but the performance trade-off may not be
+  worthwhile given that this mechanism is important when under high load.

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -8,6 +8,9 @@ Unreleased
 Features
 --------
 
+* Under high load (with many subscription updates queued up to send) servers
+  batch subscriptions into blocks, trading a little latency for efficiency.
+  Under low load, servers prioritize low latency.
 * In the threading client, process user callbacks using one threadpool *per
   circuit* instead of one threadpool for the entire context. Make the size of
   the threadpool configurable via a new
@@ -16,8 +19,8 @@ Features
   `Python 3-compatible fork <https://github.com/klauer/catvs/tree/py3k>`_ of
   Michael Davidsaver's utility for testing Channel Access servers,
   `catvs <https://github.com/mdavidsaver/catvs>`_. This has generated several
-  bug fixes, included in the list below. There are a small number of known
-  failures wherein the best/correct behavior is arguable; see
+  fixes improving protocol compliance, list a section below. There are a small
+  number of known failures wherein the best/correct behavior is arguable; see
   `caproto#327 on GitHub <https://github.com/NSLS-II/caproto/pull/327>`_ for
   discussion. There may be more progress on these in future releases of
   caproto.
@@ -48,6 +51,10 @@ Bug Fixes
   sockets when the process exited. They now close their sockets explicitly when
   the server task exits. This fixes the runaway usage of file descriptors when
   the tests are run.
+
+Improved Protocol Compliance
+----------------------------
+
 * The servers send :class:`~caproto.CreateChFailResponse` when the client
   requests a channel name that does not exist on the server. They previously
   did not respond.
@@ -55,6 +62,9 @@ Bug Fixes
   (UDP is more common, but TCP is allowed.) They previously did not respond.
 * The :class:`~caproto.EventCancelResponse` message includes a ``data_count``.
 * The servers respect the ``data_count`` requested by the client.
+* Servers enforce quota per subscription to avoid one prolific subscription (or
+  slow client) from drowning out others.
+* Servers respect ``EventsOn`` and ``EventsOff`` requests.
 
 v0.1.2 (2018-08-31)
 ===================

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -321,6 +321,21 @@ call ``go_idle()`` on any PV at any time, knowing that the PV will decline to
 disconnect if it is being actively used and that, if it is currently unused, it
 will transparently reconnect the next time it is used.
 
+Events Off and On
+-----------------
+
+If a given circuit produces updates faster than a client can process them, the
+client can suspend subscriptions on that circuit. This will causes the server
+to discard all backlogged updates and all new updates during the period of
+supsension. When the client reactives subscriptions, it will immediate receive
+the most recent update and then any future updates.
+
+.. code-block:: python
+
+   x.circuit_manager.events_off()
+   ...
+   x.circuit_manager.events_on()
+
 Loggers for Debugging
 ---------------------
 


### PR DESCRIPTION
Tested interactively, it correctly starts dropping updates for a specific Subscription on the floor if a given client is behind.

If there is a backlog of EventAddResponses to send, it starts batching them into blocks to send at once. This is tested interactively too and seems to work well.