### PR TITLE
ENH: Expose number of workers per circuit as an argument to Context

### DIFF
--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release History
 ***************
 
+Unreleased
+==========
+
+* In the threading client, process user callbacks using one threadpool *per
+  circuit* instead of one threadpool for the entire context. Make the size of
+  the threadpool configurable via a new
+  :class:`~caproto.threading.client.Context` parameter, ``max_workers``.
+
 v0.1.1 (2018-06-17)
 ===================
 


### PR DESCRIPTION
The original motivation for having one threadpool per context (and by default one worker in that threadpool) was to ensure that updates were processed in order.

This was overkill: the server itself can only guarantee ordering within a circuit; it does not coordinate *between* circuits in a context. Therefore it is safe to use one worker per circuit. This PR implements this as one threadpool per circuit, with the number of workers in the threadpool defaulting to one but configurable by the user.