### PR TITLE
ENH: pvproperty scan

### DIFF
--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -86,7 +86,7 @@ def main():
     def callback(pv_name, response):
         tokens['callback_count'] += 1
         if args.format is None:
-            format_str = ("{pv_name: <40}  {timestamp:%Y-%m-%d %H:%M:%S} "
+            format_str = ("{pv_name: <40}  {timestamp:%Y-%m-%d %H:%M:%S.%f} "
                           "{response.data}")
         else:
             format_str = args.format

--- a/caproto/ioc_examples/mini_beamline.py
+++ b/caproto/ioc_examples/mini_beamline.py
@@ -164,13 +164,10 @@ class MiniBeamline(PVGroup):
 
     current = pvproperty(value=[500], dtype=float, read_only=True)
 
-    @current.startup
+    @current.scan(period=0.1)
     async def current(self, instance, async_lib):
-        f = (2 * np.pi) / 4
-        while True:
-            t = time.monotonic()
-            await instance.write(value=[500 + 25 * np.sin(t * f)])
-            await async_lib.library.sleep(.1)
+        current = 500 + 25 * np.sin(time.monotonic() * (2 * np.pi) / 4)
+        await instance.write(value=[current])
 
     ph = SubGroup(PinHole)
     edge = SubGroup(Edge)

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -343,7 +343,7 @@ class pvproperty:
                              *self.pvspec[3:])
         return self
 
-    def scan(self, period=1, *, subtract_elapsed=True, fail_on_error=False):
+    def scan(self, period, *, subtract_elapsed=True, fail_on_error=False):
         '''Periodically call a function to update a pvproperty.
 
         NOTE: This replaces the pvproperty startup function. Only one or the

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -8,10 +8,12 @@ For an example server implementation, see caproto.curio.server
 '''
 import argparse
 import copy
-import logging
 import inspect
-from collections import (namedtuple, OrderedDict, defaultdict)
+import logging
 import sys
+import time
+
+from collections import (namedtuple, OrderedDict, defaultdict)
 from types import MethodType
 
 from .. import (ChannelDouble, ChannelInteger, ChannelString,
@@ -29,6 +31,7 @@ __all__ = ['AsyncLibraryLayer',
            'PvpropertyData', 'PvpropertyReadOnlyData',
            'PvpropertyChar', 'PvpropertyCharRO',
            'PvpropertyDouble', 'PvpropertyDoubleRO',
+           'PvpropertyBoolEnum', 'PvpropertyBoolEnumRO',
            'PvpropertyEnum', 'PvpropertyEnumRO',
            'PvpropertyInteger', 'PvpropertyIntegerRO',
            'PvpropertyString', 'PvpropertyStringRO',
@@ -339,6 +342,55 @@ class pvproperty:
         self.pvspec = PVSpec(self.pvspec.get, self.pvspec.put, startup,
                              *self.pvspec[3:])
         return self
+
+    def scan(self, period=1, *, subtract_elapsed=True, fail_on_error=False):
+        '''Periodically call a function to update a pvproperty.
+
+        NOTE: This replaces the pvproperty startup function. Only one or the
+        other can be specified.
+
+        Parameters
+        ----------
+        period : float
+            Wait `period` seconds between calls to the scanned function
+        subtract_elapsed : bool, optional
+            Subtract the elapsed time of the previous call from the period for
+            the subsequent iteration
+        fail_on_error : bool, optional
+            Fail (and stop scanning) when unhandled exceptions occur
+
+        Returns
+        -------
+        wrapper : callable
+            A wrapper that should be used with an async function matching the
+            pvproperty startup function signature:
+                (group, instance, async_library)
+        '''
+        # TODO: maybe allow rate to be tied to a PV (e.g., a SCAN field?)
+        def wrapper(scan_function):
+            async def scanned_startup(group, prop, async_lib):
+                sleep = async_lib.library.sleep
+                while True:
+                    t0 = time.monotonic()
+
+                    try:
+                        await scan_function(group, prop, async_lib)
+                    except Exception as ex:
+                        prop.log.exception('Scan exception')
+                        if fail_on_error:
+                            raise
+
+                    elapsed = time.monotonic() - t0
+                    sleep_time = (max(0, period - elapsed)
+                                  if subtract_elapsed
+                                  else period)
+                    await sleep(sleep_time)
+            return self.startup(scanned_startup)
+
+        if period <= 0:
+            raise ValueError('Scan period must be > 0')
+
+        return wrapper
 
     def __call__(self, get, put=None, startup=None):
         # handles case where pvproperty(**spec_kw)(getter, putter, startup) is


### PR DESCRIPTION
Addresses #324 

A simple enhancement without requiring further modification of `PVSpec`.
Added microseconds in `caproto-monitor` output so you can see current updating; example with timedelta in the expandable section below. Upsides/downsides follow.

<details>

```
$ caproto-monitor mini:current --format "{timedelta} {response.data}"
0:00:00.006681 [ 482.31322727]
0:00:00.100726 [ 479.75035273]
0:00:00.100883 [ 477.69062017]
0:00:00.100941 [ 476.18900918]
0:00:00.100933 [ 475.28488873]
0:00:00.100950 [ 475.00069802]
0:00:00.100884 [ 475.34340477]
0:00:00.100908 [ 476.30423468]
0:00:00.100922 [ 477.85958347]
0:00:00.100883 [ 479.96916718]
0:00:00.100905 [ 482.58100906]
0:00:00.100950 [ 485.63166917]
0:00:00.100878 [ 489.03979987]
0:00:00.100914 [ 492.72308764]
0:00:00.100854 [ 496.58860719]
0:00:00.100844 [ 500.53803125]
0:00:00.100889 [ 504.47535031]
0:00:00.100932 [ 508.30248872]
0:00:00.100960 [ 511.92256529]
0:00:00.100870 [ 515.24037703]
0:00:00.100853 [ 518.17585173]
0:00:00.100844 [ 520.6560495]
0:00:00.100873 [ 522.61922787]
0:00:00.100957 [ 524.01691809]
0:00:00.100853 [ 524.81131275]
0:00:00.100833 [ 524.98429688]
0:00:00.100844 [ 524.53175265]
0:00:00.100907 [ 523.46419109]
0:00:00.100961 [ 521.80724613]
0:00:00.100964 [ 519.60292215]
0:00:00.100920 [ 516.90758773]
0:00:00.100859 [ 513.79041532]
0:00:00.100832 [ 510.32893129]
0:00:00.100864 [ 506.6076483]
0:00:00.100901 [ 502.7195926]
0:00:00.100905 [ 498.76267889]
```

</details>

Pluses:
- PVSpec doesn't get any bigger

Minuses:
- Keeping pvproperty based on the specification of `PVSpec` keeps them very flexible and easily reusable

Future
- May want to be able to tie in another property that allows for modification of the scan rate (e.g., a `.SCAN` field in a mocked record