### PR TITLE
DOC: Correct inaccurate docstring.

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -739,7 +739,8 @@ class Context:
             Expected signature: ``f(pv, state)`` where ``pv`` is the instance
             of ``PV`` whose state has changed and ``state`` is a string
         access_rights_callback : callable
-            Expected signature: ``f(access_rights)`` where ``access_rights`` is
+            Expected signature: ``f(pv, access_rights)`` where ``pv`` is the
+            instance of ``PV`` whose state has changed and ``access_rights`` is
             a member of the caproto ``AccessRights`` enum
 
         """
@@ -1291,7 +1292,7 @@ class PV:
             self._channel = val
 
     def access_rights_changed(self, rights):
-        self.access_rights_callback.process(rights)
+        self.access_rights_callback.process(self, rights)
 
     def connection_state_changed(self, state, channel):
         self.log.info('%s connection state changed to %s.', self.name, state)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -736,7 +736,8 @@ class Context:
             Used by the server to triage subscription responses when under high
             load. 0 is lowest; 99 is highest.
         connection_state_callback : callable
-            Expected signature: ``f(state)`` where ``state`` is a string
+            Expected signature: ``f(pv, state)`` where ``pv`` is the instance
+            of ``PV`` whose state has changed and ``state`` is a string
         access_rights_callback : callable
             Expected signature: ``f(access_rights)`` where ``access_rights`` is
             a member of the caproto ``AccessRights`` enum

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -501,7 +501,8 @@ class PV:
         self._access_rights_changed(self._caproto_pv.channel.access_rights,
                                     forced=True)
 
-    def _access_rights_changed(self, access_rights, *, forced=False):
+    def _access_rights_changed(self, caproto_pv, access_rights, *,
+                               forced=False):
         read_access = AccessRights.READ in access_rights
         write_access = AccessRights.WRITE in access_rights
         access_strs = ('no access', 'read-only', 'write-only', 'read/write')

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -9,6 +9,9 @@ Unreleased
   circuit* instead of one threadpool for the entire context. Make the size of
   the threadpool configurable via a new
   :class:`~caproto.threading.client.Context` parameter, ``max_workers``.
+* The expected signature of the ``access_rights_callback`` passed to
+  :class:`~caproto.threading.client.Context` has been changed from
+  ``f(access_rights)`` to ``f(pv, access_rights)``.
 
 v0.1.1 (2018-06-17)
 ===================


### PR DESCRIPTION
This prompts the question, should we change the API of the access_rights_callback
to be the same --- to take the PV instance as the first argument? I think that
we should.