### PR TITLE
ENH: In CLIs, accept -vvvvvvvv(etc) as a synonym for -vvv.

### DIFF
--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -23,10 +23,8 @@ def main():
     fmt_group = parser.add_mutually_exclusive_group()
     parser.add_argument('pv_names', type=str, nargs='+',
                         help="PV (channel) name(s) separated by spaces")
-    parser.add_argument('--verbose', '-v', action='store_true',
+    parser.add_argument('--verbose', '-v', action='count',
                         help="Verbose mode. (Use -vvv for more.)")
-    parser.add_argument('-vvv', action='store_true',
-                        help=argparse.SUPPRESS)
     fmt_group.add_argument('--format', type=str,
                            help=("Python format string. Available tokens are "
                                  "{pv_name} and {response}. Additionally, if "
@@ -79,8 +77,8 @@ def main():
     if args.verbose:
         logging.getLogger(f'caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')
-    if args.vvv:
-        logging.getLogger('caproto').setLevel('DEBUG')
+        if args.verbose > 2:
+            logging.getLogger('caproto').setLevel('DEBUG')
     data_type = args.d
     # data_type might be '0', 'STRING', or a class like 'control'.
     # The client functions accepts 0, ChannelType.STRING, or 'control'.
@@ -121,7 +119,7 @@ def main():
             print(format_str.format(**tokens))
 
     except BaseException as exc:
-        if args.verbose or args.vvv:
+        if args.verbose:
             # Show the full traceback.
             raise
         else:

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -32,10 +32,8 @@ def main():
                                  "time, {timestamp}, {timedelta} and usages "
                                  "like {timestamp:%%Y-%%m-%%d %%H:%%M:%%S} are"
                                  " supported."))
-    parser.add_argument('--verbose', '-v', action='store_true',
+    parser.add_argument('--verbose', '-v', action='count',
                         help="Show DEBUG log messages.")
-    parser.add_argument('-vvv', action='store_true',
-                        help=argparse.SUPPRESS)
     exit_group.add_argument('--duration', type=float, default=None,
                             help=("Maximum number seconds to run before "
                                   "exiting. Runs indefinitely by default."))
@@ -67,8 +65,8 @@ def main():
     if args.verbose:
         logging.getLogger('caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')
-    if args.vvv:
-        logging.getLogger('caproto').setLevel('DEBUG')
+        if args.verbose > 2:
+            logging.getLogger('caproto').setLevel('DEBUG')
 
     mask = 0
     if 'v' in args.m:
@@ -125,7 +123,7 @@ def main():
               force_int_enums=args.n,
               repeater=not args.no_repeater)
     except BaseException as exc:
-        if args.verbose or args.vvv:
+        if args.verbose:
             # Show the full traceback.
             raise
         else:

--- a/caproto/commandline/put.py
+++ b/caproto/commandline/put.py
@@ -25,10 +25,8 @@ def main():
                         help="PV (channel) name")
     parser.add_argument('data', type=str,
                         help="Value or values to write.")
-    parser.add_argument('--verbose', '-v', action='store_true',
+    parser.add_argument('--verbose', '-v', action='count',
                         help="Show DEBUG log messages.")
-    parser.add_argument('-vvv', action='store_true',
-                        help=argparse.SUPPRESS)
     fmt_group.add_argument('--format', type=str,
                            help=("Python format string. Available tokens are "
                                  "{pv_name}, {response} and {which} (Old/New)."
@@ -71,8 +69,8 @@ def main():
     if args.verbose:
         logging.getLogger(f'caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')
-    if args.vvv:
-        logging.getLogger('caproto').setLevel('DEBUG')
+        if args.verobse > 2:
+            logging.getLogger('caproto').setLevel('DEBUG')
     logger = logging.getLogger(f'caproto.ch.{args.pv_name}')
     try:
         data = ast.literal_eval(args.data)
@@ -116,7 +114,7 @@ def main():
             tokens['timestamp'] = dt
         print(format_str.format(which='New', **tokens))
     except BaseException as exc:
-        if args.verbose or args.vvv:
+        if args.verbose:
             # Show the full traceback.
             raise
         else:

--- a/caproto/commandline/repeater.py
+++ b/caproto/commandline/repeater.py
@@ -32,16 +32,14 @@ EPICS_CA_REPEATER_PORT. It defaults to the standard 5065. The current value is
     group.add_argument('-q', '--quiet', action='store_true',
                        help=("Suppress INFO log messages. "
                              "(Still show WARNING or higher.)"))
-    group.add_argument('-v', '--verbose', action='store_true',
+    group.add_argument('-v', '--verbose', action='count',
                        help="Verbose mode. (Use -vvv for more.)")
-    group.add_argument('-vvv', action='store_true',
-                       help=argparse.SUPPRESS)
     parser.add_argument('--no-color', action='store_true',
                         help="Suppress ANSI color codes in log messages.")
     args = parser.parse_args()
     if args.no_color:
         color_logs(False)
-    if args.vvv:
+    if args.verbose and args.verbose > 2:
         logging.getLogger('caproto').setLevel('DEBUG')
     else:
         if args.verbose:
@@ -54,7 +52,7 @@ EPICS_CA_REPEATER_PORT. It defaults to the standard 5065. The current value is
     try:
         run()
     except BaseException as exc:
-        if args.verbose or args.vvv:
+        if args.verbose:
             # Show the full traceback.
             raise
         else:


### PR DESCRIPTION
I remember someone (@tacaswell) remarking that it is annoying that ``-vvvv`` is
less verbose than ``-vvv``, and it's easy enought to make ``-v`` a "count"
thing rather than a "store_true" thing. This is also exactly how ansible's
verbosity CLI flag is handled, as a point of precedent.