### PR TITLE
TST: increase barrier wait time due to travis slowness

### DIFF
--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 
 from ._constants import (DEFAULT_PROTOCOL_VERSION, MAX_ID)
-from ._utils import (CLIENT, SERVER, CaprotoValueError, LocalProtocolError,
+from ._utils import (CLIENT, SERVER, CaprotoValueError,
                      RemoteProtocolError)
 from ._state import get_exception
 from ._commands import (RepeaterConfirmResponse, RepeaterRegisterRequest,

--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -47,7 +47,6 @@ class Broadcaster:
         # track for the Broadcaster. We don't need a full state machine, just
         # one flag to check whether we have yet registered with a repeater.
         self._registered = False
-        self._attempted_registration = False
         self._search_id_counter = itertools.count(0)
         self.log = logging.getLogger(f"caproto.bcast")
 
@@ -130,18 +129,7 @@ class Broadcaster:
             This input will be mutated: command will be appended at the end.
         """
         # All commands go through here.
-        if isinstance(command, RepeaterRegisterRequest):
-            self._attempted_registration = True
-        elif isinstance(command, RepeaterConfirmResponse):
-            self._registered = True
-        elif (role is CLIENT and
-              self.our_role is CLIENT and
-              not self._attempted_registration):
-            raise LocalProtocolError("Client must send a "
-                                     "RegisterRepeaterRequest before any "
-                                     "other commands (saw: {})"
-                                     "".format(type(command).__name__))
-        elif isinstance(command, SearchRequest):
+        if isinstance(command, SearchRequest):
             if VersionRequest not in map(type, history):
                 err = get_exception(self.our_role, command)
                 raise err("A broadcasted SearchResponse must be preceded by a "
@@ -155,6 +143,8 @@ class Broadcaster:
             #     raise err("A broadcasted SearchResponse must be preceded by "
             #               "a VersionResponse in the same datagram.")
             self.unanswered_searches.pop(command.cid, None)
+        elif isinstance(command, RepeaterConfirmResponse):
+            self._registered = True
 
         history.append(command)
 
@@ -212,21 +202,11 @@ class Broadcaster:
         if ip is None:
             ip = '0.0.0.0'
         command = RepeaterRegisterRequest(ip)
-
-        # NOTE: consider this enough for a registration attempt.
-        # TODO this is required for moving forward with the threading client,
-        # and may be implemented better in the future
-        self._attempted_registration = True
         return command
 
     def disconnect(self):
         self._registered = False
-        self._attempted_registration = False
 
     @property
     def registered(self):
         return self._registered
-
-    @property
-    def attempted_registration(self):
-        return self._attempted_registration

--- a/caproto/_state.py
+++ b/caproto/_state.py
@@ -176,6 +176,10 @@ COMMAND_TRIGGERED_CHANNEL_TRANSITIONS = {
         },
         CLOSED: {
             # a terminal state
+            # Sometimes RSRV sends EventCancelResponse messages too late, so we
+            # have to tolerate it. This is against the spec, FWIW, and caproto
+            # servers do not do this.
+            EventCancelResponse: CLOSED,
         },
         FAILED: {
             # a terminal state

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -377,8 +377,8 @@ def multi_iterations(request):
     return request.param
 
 
-def _multithreaded_exec(test_func, thread_count, *, start_timeout=5,
-                        end_timeout=2):
+def _multithreaded_exec(test_func, thread_count, *, start_timeout=10,
+                        end_timeout=20):
     threads = {}
     return_values = {i: None for i in range(thread_count)}
     start_barrier = threading.Barrier(parties=thread_count + 1)
@@ -506,12 +506,11 @@ def test_multithreaded_many_write(ioc, context, thread_count,
     sub.clear()
 
 
-@pytest.mark.xfail
 def test_multithreaded_many_subscribe(ioc, context, thread_count,
                                       multi_iterations):
     def _test(thread_id):
         if thread_id == 0:
-            init_barrier.wait(timeout=2)
+            init_barrier.wait(timeout=10)
             print('-- write thread initialized --')
             pv.write((1, ), wait=True)
             time.sleep(0.01)
@@ -520,7 +519,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
             pv.write((3, ), wait=True)
             time.sleep(0.2)
             print('-- write thread hit sub barrier --')
-            sub_ended_barrier.wait(timeout=2)
+            sub_ended_barrier.wait(timeout=10)
             print('-- write thread exiting --')
             return [initial_value, 1, 2, 3]
 
@@ -534,11 +533,11 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         sub.add_callback(callback)
         time.sleep(0.2)  # Wait for EventAddRequest to be sent and processed.
         # print(thread_id, sub)
-        init_barrier.wait(timeout=2)
+        init_barrier.wait(timeout=10)
         # Everybody here? On my signal... SUBSCRIBE!! Ahahahahaha!
         # Destruction!!
         time.sleep(1)  # Wait for EventAddRequest to be sent and processed.
-        sub_ended_barrier.wait(timeout=2)
+        sub_ended_barrier.wait(timeout=10)
 
         sub.clear()
         return values[thread_id]

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -539,7 +539,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         else:
             raise Exception(f"{thread_id} never saw initial EventAddResponse")
         # print(thread_id, sub)
-        init_barrier.wait(timeout=2)
+        init_barrier.wait(timeout=20)
         # Everybody here? On my signal... SEND UPDATES!! Ahahahahaha!
         # Destruction!!
         # Wait <= 20 seconds until three more EventAddResponses are received.
@@ -550,7 +550,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         else:
             raise Exception(f"{thread_id} only got {len(values[thread_id])}"
                             f"EventAddResponses.")
-        sub_ended_barrier.wait(timeout=10)
+        sub_ended_barrier.wait(timeout=20)
 
         sub.clear()
         return values[thread_id]

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -531,8 +531,8 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
 
         sub = pv.subscribe()
         sub.add_callback(callback)
-        # Wait <= 2 seconds for EventAddRequest to be sent and processed.
-        for i in range(20):
+        # Wait <= 20 seconds until first EventAddResponse is received.
+        for i in range(200):
             if values[thread_id]:
                 break
             time.sleep(0.1)
@@ -542,7 +542,14 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
         init_barrier.wait(timeout=2)
         # Everybody here? On my signal... SEND UPDATES!! Ahahahahaha!
         # Destruction!!
-        time.sleep(1)  # Wait for EventAddRequest to be sent and processed.
+        # Wait <= 20 seconds until three more EventAddResponses are received.
+        for i in range(200):
+            if len(values[thread_id]) == 4:
+                break
+            time.sleep(0.1)
+        else:
+            raise Exception(f"{thread_id} only got {len(values[thread_id])}"
+                            f"EventAddResponses.")
         sub_ended_barrier.wait(timeout=10)
 
         sub.clear()

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -531,10 +531,16 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
 
         sub = pv.subscribe()
         sub.add_callback(callback)
-        time.sleep(0.2)  # Wait for EventAddRequest to be sent and processed.
+        # Wait <= 2 seconds for EventAddRequest to be sent and processed.
+        for i in range(20):
+            if values[thread_id]:
+                break
+            time.sleep(0.1)
+        else:
+            raise Exception(f"{thread_id} never saw initial EventAddResponse")
         # print(thread_id, sub)
-        init_barrier.wait(timeout=10)
-        # Everybody here? On my signal... SUBSCRIBE!! Ahahahahaha!
+        init_barrier.wait(timeout=2)
+        # Everybody here? On my signal... SEND UPDATES!! Ahahahahaha!
         # Destruction!!
         time.sleep(1)  # Wait for EventAddRequest to be sent and processed.
         sub_ended_barrier.wait(timeout=10)

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -506,6 +506,7 @@ def test_multithreaded_many_write(ioc, context, thread_count,
     sub.clear()
 
 
+@pytest.mark.xfail
 def test_multithreaded_many_subscribe(ioc, context, thread_count,
                                       multi_iterations):
     def _test(thread_id):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -345,6 +345,9 @@ class SharedBroadcaster:
         self._registration_retry_time = registration_retry_time
         self._registration_last_sent = 0
 
+        self.udp_sock = ca.bcast_socket()
+        self.selector.add_socket(self.udp_sock, self)
+
         try:
             # Always attempt registration on initialization, but allow failures
             self._register()
@@ -368,9 +371,6 @@ class SharedBroadcaster:
 
     def _register(self):
         'Send a registration request to the repeater'
-        if self.udp_sock is None:
-            self._create_sock()
-
         self._registration_last_sent = time.monotonic()
         command = self.broadcaster.register()
 
@@ -384,15 +384,6 @@ class SharedBroadcaster:
                 self._id_counter = itertools.count(0)
                 continue
             return i
-
-    def _create_sock(self):
-        # UDP socket broadcasting to CA servers
-        if self.udp_sock is not None:
-            udp_sock, self.udp_sock = self.udp_sock, None
-            self.selector.remove_socket(udp_sock)
-
-        self.udp_sock = ca.bcast_socket()
-        self.selector.add_socket(self.udp_sock, self)
 
     def add_listener(self, listener):
         with self._search_lock:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -2019,7 +2019,10 @@ class Subscription(CallbackHandler):
                 try:
                     func(most_recent_response)
                 except Exception as ex:
-                    print(ex)
+                    self.log.exception(
+                        "Exception raised during processing most recent "
+                        "response %r with new callback %r",
+                        most_recent_response, func)
 
         return cb_id
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1354,7 +1354,6 @@ class VirtualCircuitManager:
             self.all_created_pvnames.append(pv.name)
             with pv.component_lock:
                 pv.channel = chan
-                cm = pv.circuit_manager
                 pv.channel_ready.set()
             pv.connection_state_changed('connected', chan)
         elif isinstance(command, (ca.ServerDisconnResponse,
@@ -2013,7 +2012,7 @@ class Subscription(CallbackHandler):
             if most_recent_response is not None:
                 try:
                     func(most_recent_response)
-                except Exception as ex:
+                except Exception:
                     self.log.exception(
                         "Exception raised during processing most recent "
                         "response %r with new callback %r",

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1513,7 +1513,9 @@ class PV:
         self.connection_state_callback.process(self, state)
         if state == 'disconnected':
             for sub in self.subscriptions.values():
-                sub.needs_reactivation = True
+                with sub.callback_lock:
+                    if sub.callbacks:
+                        sub.needs_reactivation = True
         if state == 'connected':
             cm = self.circuit_manager
             ctx = cm.context


### PR DESCRIPTION
Based on what I've seen locally with barrier breakage using 100 to 300+ threads, it seems that the time needed to complete these tests on travis is significantly greater than when run locally. Let's see if this makes multithreaded tests pass more repeatably.