### PR TITLE
CLN: initial attempt at cleaning conversions

### DIFF
--- a/caproto/_array_backend.py
+++ b/caproto/_array_backend.py
@@ -1,10 +1,9 @@
 import array
 import ctypes
 import sys
-from ._backend import Backend, register_backend
-from ._dbr import (ChannelType, DbrStringArray,
-                   native_int_types, native_float_types,
-                   native_types, DBR_TYPES)
+from ._backend import Backend, register_backend, convert_values
+from ._dbr import (ChannelType, DbrStringArray, native_int_types,
+                   native_float_types, native_types, DBR_TYPES)
 
 
 default_endian = ('>' if sys.byteorder == 'big'
@@ -120,6 +119,7 @@ def _setup():
                    type_map=type_map,
                    epics_to_python=epics_to_python,
                    python_to_epics=python_to_epics,
+                   convert_values=convert_values,
                    )
 
 

--- a/caproto/_backend.py
+++ b/caproto/_backend.py
@@ -5,6 +5,11 @@ import collections
 import logging
 from types import SimpleNamespace
 
+from ._dbr import (ChannelType, native_float_types, native_int_types,
+                   native_types, DbrStringArray)
+
+from ._utils import ConversionDirection, CaprotoConversionError
+
 
 __all__ = ('backend', 'Backend', 'register_backend', 'select_backend')
 logger = logging.getLogger('caproto')
@@ -22,7 +27,7 @@ _backends = {}
 _initialized = False  # Has any backend be selected yet?
 Backend = collections.namedtuple(
     'Backend',
-    'name epics_to_python python_to_epics type_map array_types'
+    'name convert_values epics_to_python python_to_epics type_map array_types'
 )
 
 
@@ -46,9 +51,295 @@ def select_backend(name):
     backend.epics_to_python = _backend.epics_to_python
     backend.type_map = _backend.type_map
     backend.array_types = _backend.array_types
+    backend.convert_values = _backend.convert_values
 
 
 backend = SimpleNamespace(
     backend_name=None, python_to_epics=None, epics_to_python=None,
-    type_map=None, array_types=None
+    type_map=None, array_types=None, convert_values=None,
 )
+
+
+def encode_or_fail(s, encoding):
+    if isinstance(s, str):
+        if encoding is None:
+            raise CaprotoConversionError('String encoding required')
+        return s.encode(encoding)
+    elif isinstance(s, bytes):
+        return s
+
+    raise CaprotoConversionError('Expected string or bytes')
+
+
+def decode_or_fail(s, encoding):
+    if isinstance(s, bytes):
+        if encoding is None:
+            raise CaprotoConversionError('String encoding required')
+        return s.decode(encoding)
+    elif isinstance(s, str):
+        return s
+
+    raise CaprotoConversionError('Expected string or bytes')
+
+
+def _preprocess_enum_values(values, to_dtype, string_encoding, enum_strings):
+    if isinstance(values, (str, bytes)):
+        values = [values]
+
+    if enum_strings is None:
+        raise CaprotoConversionError('enum_strings not specified')
+
+    num_strings = len(enum_strings)
+
+    if to_dtype == ChannelType.STRING:
+        def enum_to_string(v):
+            if isinstance(v, bytes):
+                raise CaprotoConversionError('Enum strings must be integer or string')
+            elif isinstance(v, str):
+                if v not in enum_strings:
+                    raise CaprotoConversionError(f'Invalid enum string: {v!r}')
+                return v
+
+            if 0 <= v < num_strings:
+                return enum_strings[int(v)]
+            raise CaprotoConversionError(f'Invalid enum index: {v!r} '
+                                         f'count={num_strings}')
+        return [enum_to_string(v) for v in values]
+
+    def enum_to_int(v):
+        if isinstance(v, bytes):
+            raise CaprotoConversionError('Enum strings must be integer or string')
+        elif isinstance(v, str):
+            try:
+                return enum_strings.index(v)
+            except ValueError:
+                raise CaprotoConversionError(f'Invalid enum string: {v!r}')
+
+        if 0 <= v < num_strings:
+            return int(v)
+        raise CaprotoConversionError(f'Invalid enum index: {v!r} '
+                                     f'count={num_strings}')
+
+    return [enum_to_int(v) for v in values]
+
+
+def _preprocess_char_from_wire(values, to_dtype, string_encoding, enum_strings):
+    'From wire: pre-process EPICS CHAR data for conversion to to_dtype'
+    if isinstance(values, list):
+        # This is from the wire, so it has to be a single value
+        bytes_from_wire = values[0]
+    else:
+        bytes_from_wire = values
+
+    bytes_from_wire = bytes_from_wire.tobytes()
+
+    if to_dtype in (ChannelType.STRING, ChannelType.CHAR):
+        if not string_encoding:
+            if to_dtype == ChannelType.STRING:
+                return [bytes_from_wire]
+            else:
+                return bytes_from_wire
+
+        values = bytes_from_wire.decode(string_encoding)
+        try:
+            return values[:values.index('\x00')]
+        except ValueError:
+            return values
+
+    # if not converting to a string, we need a list of numbers.
+    # b'bytes' -> [ord('b'), ord('y'), ...]
+    return list(bytes_from_wire)
+
+
+def _preprocess_char_to_wire(values, to_dtype, string_encoding, enum_strings):
+    'To wire: pre-process python-stored CHAR values for conversion to to_dtype'
+    if isinstance(values, list) and len(values) == 1:
+        values = values[0]
+
+    if to_dtype == ChannelType.STRING:
+        # NOTE: accurate, but results in very inefficient CA response
+        #       Bytes required: 40 * num_chars (i.e., 40 * len(values))
+        if isinstance(values, (str, bytes)):
+            # a length 3 char value is converted to 3 strings:
+            # b'abc' -> [b'a', b'b', b'c']
+            #  'abc' -> [b'a', b'b', b'c']
+            # this is, of course, different from returning b'abc', which would
+            # be converted to a single string on the wire.
+            return [bytes([v]) for v in encode_or_fail(values, string_encoding)]
+        else:
+            # list of numbers - these will be converted as follows:
+            # [1, 2, 3] -> ['1', '2', '3']
+            return values
+
+    # if not converting to a string, we need a list of numbers.
+    if isinstance(values, (str, bytes)):
+        if isinstance(values, str):
+            values = encode_or_fail(values, string_encoding)
+        # b'bytes' -> [ord('b'), ord('y'), ...]
+        return list(values)
+
+    # CHAR data is stored as integers
+    try:
+        values[0]
+    except TypeError:
+        # example: values = 5
+        return [values]
+    else:
+        # example: values = [5, 6, 7]
+        return values
+
+
+def _decode_string_list(values, string_encoding):
+    'List of bytes, strings, values -> list of decoded strings'
+    def get_value(v):
+        if isinstance(v, bytes):
+            if string_encoding:  # can have bytes in ChannelString
+                return v.decode(string_encoding)
+            return v
+        elif isinstance(v, str):
+            return v
+        else:
+            return str(v)
+    return [get_value(v) for v in values]
+
+
+def _encode_to_string_array(values, string_encoding):
+    'List of bytes, strings, values -> DbrStringArray'
+    def get_value(v):
+        if isinstance(v, bytes):
+            return v
+        elif isinstance(v, str):
+            return encode_or_fail(v, string_encoding)
+        else:
+            return encode_or_fail(str(v), string_encoding)
+    return DbrStringArray(get_value(v) for v in values)
+
+
+def _preprocess_string_from_wire(values, to_dtype, string_encoding,
+                                 enum_strings):
+    if to_dtype == ChannelType.STRING:
+        # caller will handle string decoding
+        return values
+
+    if to_dtype == ChannelType.ENUM:
+        values = [decode_or_fail(v, string_encoding)
+                  if isinstance(v, bytes)
+                  else v
+                  for v in values]
+
+        # conversion for when this is used: `caput enum_pv string_value`
+        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
+                                       string_encoding=string_encoding,
+                                       enum_strings=enum_strings)
+    elif to_dtype in native_int_types:
+        # TODO ca_test: for enums, string arrays seem to work, but not
+        # scalars?
+        return [int(v) for v in values]
+    elif to_dtype in native_float_types:
+        return [float(v) for v in values]
+
+
+def _preprocess_string_to_wire(values, to_dtype, string_encoding,
+                               enum_strings):
+    if isinstance(values, (str, bytes)):
+        values = [values]
+
+    # from here on, we are dealing with a list of strings/bytes
+    if to_dtype == ChannelType.STRING:
+        # caller will handle string encoding
+        return values
+    elif to_dtype == ChannelType.ENUM:
+        # for enums, decode bytes -> strings
+        values = [decode_or_fail(v, string_encoding)
+                  if isinstance(v, bytes)
+                  else v
+                  for v in values]
+        # conversion for when this is used: `caput enum_pv string_value`
+        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
+                                       string_encoding=string_encoding,
+                                       enum_strings=enum_strings)
+    elif to_dtype in native_int_types:
+        return [int(v) for v in values]
+    elif to_dtype in native_float_types:
+        return [float(v) for v in values]
+
+
+_custom_preprocess = {
+    (ChannelType.ENUM, ConversionDirection.TO_WIRE): _preprocess_enum_values,
+    (ChannelType.ENUM, ConversionDirection.FROM_WIRE): _preprocess_enum_values,
+    (ChannelType.CHAR, ConversionDirection.FROM_WIRE): _preprocess_char_from_wire,
+    (ChannelType.CHAR, ConversionDirection.TO_WIRE): _preprocess_char_to_wire,
+    (ChannelType.STRING, ConversionDirection.FROM_WIRE): _preprocess_string_from_wire,
+    (ChannelType.STRING, ConversionDirection.TO_WIRE): _preprocess_string_to_wire,
+}
+
+
+def convert_values(values, from_dtype, to_dtype, *, direction,
+                   string_encoding='latin-1', enum_strings=None,
+                   auto_byteswap=True):
+    '''Convert values from one ChannelType to another
+
+    Parameters
+    ----------
+    values :
+    from_dtype : caproto.ChannelType
+        The dtype of the values
+    to_dtype : caproto.ChannelType
+        The dtype to convert to
+    direction : caproto.ConversionDirection
+        Direction of conversion, from or to the wire
+    string_encoding : str, optional
+        The encoding to be used for strings
+    enum_strings : list, optional
+        List of enum strings, if available
+    auto_byteswap : bool, optional
+        If sending over the wire and using built-in arrays, the data should
+        first be byte-swapped to big-endian.
+    '''
+
+    if (from_dtype in (ChannelType.STSACK_STRING, ChannelType.CLASS_NAME) or
+            (to_dtype in (ChannelType.STSACK_STRING, ChannelType.CLASS_NAME))):
+        if from_dtype != to_dtype:
+            raise CaprotoConversionError(
+                'Cannot convert values for stsack_string or class_name to '
+                'other types')
+        return values
+
+    if to_dtype not in native_types or from_dtype not in native_types:
+        raise CaprotoConversionError('Expecting a native type')
+
+    if not isinstance(values, (str, bytes)):
+        try:
+            len(values)
+        except TypeError:
+            values = [values]
+
+    try:
+        preprocess = _custom_preprocess[(from_dtype, direction)]
+    except KeyError:
+        ...
+    else:
+        try:
+            values = preprocess(values=values, to_dtype=to_dtype,
+                                string_encoding=string_encoding,
+                                enum_strings=enum_strings)
+        except Exception as ex:
+            raise CaprotoConversionError() from ex
+
+        if to_dtype == ChannelType.STRING and isinstance(values, (str, bytes)):
+            values = [values]
+
+    if to_dtype == ChannelType.STRING:
+        if direction == ConversionDirection.TO_WIRE:
+            return _encode_to_string_array(values, string_encoding)
+        else:
+            return _decode_string_list(values, string_encoding)
+    elif to_dtype == ChannelType.CHAR:
+        if string_encoding and isinstance(values[0], str):
+            return values
+        elif not string_encoding and isinstance(values[0], bytes):
+            return values
+
+    byteswap = (auto_byteswap and direction == ConversionDirection.TO_WIRE)
+    return backend.python_to_epics(to_dtype, values, byteswap=byteswap,
+                                   convert_from=from_dtype)

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -8,7 +8,7 @@
 # Responses.
 import itertools
 import logging
-import collections
+from collections import deque, Iterable
 import os
 
 from ._commands import (AccessRightsResponse, CreateChFailResponse,
@@ -166,7 +166,7 @@ class VirtualCircuit:
         ``(commands, num_bytes_needed)``
         """
         total_received = sum(len(byteslike) for byteslike in buffers)
-        commands = collections.deque()
+        commands = deque()
         if total_received == 0:
             self.log.debug('Zero-length recv; sending disconnect notification')
             commands.append(DISCONNECTED)
@@ -655,9 +655,9 @@ class ClientChannel(_BaseChannel):
         if native_type(data_type) != ChannelType.CHAR:
             if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
                 data = [data]
-            if data and isinstance(data[0], str):
+            if len(data) and isinstance(data[0], str):
                 data = [val.encode(self.string_encoding) for val in data]
-        elif data and isinstance(data[0], str):
+        elif len(data) and isinstance(data[0], str):
                 data = data.encode(self.string_encoding)
         if data_count == 0:
             data_count = len(data)
@@ -831,9 +831,9 @@ class ServerChannel(_BaseChannel):
         if native_type(data_type) != ChannelType.CHAR:
             if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
                 data = [data]
-            if data and isinstance(data[0], str):
+            if len(data) and isinstance(data[0], str):
                 data = [val.encode(self.string_encoding) for val in data]
-        elif data and isinstance(data[0], str):
+        elif len(data) and isinstance(data[0], str):
                 data = data.encode(self.string_encoding)
         cls = ReadNotifyResponse if notify else ReadResponse
         command = cls(data, data_type, data_count, status, ioid,

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -828,13 +828,15 @@ class ServerChannel(_BaseChannel):
         ReadResponse or ReadNotifyResponse
         """
         data_type, data_count = self._fill_defaults(data_type, data_count)
-        if native_type(data_type) != ChannelType.CHAR:
-            if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
-                data = [data]
-            if len(data) and isinstance(data[0], str):
-                data = [val.encode(self.string_encoding) for val in data]
-        elif len(data) and isinstance(data[0], str):
-                data = data.encode(self.string_encoding)
+        # TODO: Un-comment this to make the server symmetric with the channel.
+        # Some work is needed to integrate it with the server/ChannelData.
+        # if native_type(data_type) != ChannelType.CHAR:
+        #     if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
+        #         data = [data]
+        #     if len(data) and isinstance(data[0], str):
+        #         data = [val.encode(self.string_encoding) for val in data]
+        # elif len(data) and isinstance(data[0], str):
+        #         data = data.encode(self.string_encoding)
         cls = ReadNotifyResponse if notify else ReadResponse
         command = cls(data, data_type, data_count, status, ioid,
                       metadata=metadata)

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -657,6 +657,8 @@ class ClientChannel(_BaseChannel):
                 data = [data]
             if data and isinstance(data[0], str):
                 data = [val.encode(self.string_encoding) for val in data]
+        elif data and isinstance(data[0], str):
+                data = data.encode(self.string_encoding)
         if data_count == 0:
             data_count = len(data)
         if ioid is None:
@@ -831,6 +833,8 @@ class ServerChannel(_BaseChannel):
                 data = [data]
             if data and isinstance(data[0], str):
                 data = [val.encode(self.string_encoding) for val in data]
+        elif data and isinstance(data[0], str):
+                data = data.encode(self.string_encoding)
         cls = ReadNotifyResponse if notify else ReadResponse
         command = cls(data, data_type, data_count, status, ioid,
                       metadata=metadata)

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -658,7 +658,7 @@ class ClientChannel(_BaseChannel):
             if len(data) and isinstance(data[0], str):
                 data = [val.encode(self.string_encoding) for val in data]
         elif len(data) and isinstance(data[0], str):
-                data = data.encode(self.string_encoding)
+            data = data.encode(self.string_encoding)
         if data_count == 0:
             data_count = len(data)
         if ioid is None:
@@ -836,7 +836,7 @@ class ServerChannel(_BaseChannel):
         #     if len(data) and isinstance(data[0], str):
         #         data = [val.encode(self.string_encoding) for val in data]
         # elif len(data) and isinstance(data[0], str):
-        #         data = data.encode(self.string_encoding)
+        #     data = data.encode(self.string_encoding)
         cls = ReadNotifyResponse if notify else ReadResponse
         command = cls(data, data_type, data_count, status, ioid,
                       metadata=metadata)

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -5,22 +5,21 @@
 # higher-level server.
 from collections import defaultdict, Iterable
 import copy
-import enum
 import time
 import warnings
 import weakref
 
-from ._dbr import (DBR_TYPES, ChannelType, native_type, native_float_types,
-                   native_int_types, native_types, timestamp_to_epics,
-                   time_types, DBR_STSACK_STRING, AccessRights,
-                   GraphicControlBase, AlarmStatus, AlarmSeverity,
-                   SubscriptionType, DbrStringArray)
+from ._dbr import (DBR_TYPES, ChannelType, native_type, native_types,
+                   timestamp_to_epics, time_types, DBR_STSACK_STRING,
+                   AccessRights, GraphicControlBase, AlarmStatus,
+                   AlarmSeverity, SubscriptionType)
 
-from ._utils import CaprotoError, CaprotoValueError
+from ._utils import CaprotoError, CaprotoValueError, ConversionDirection
 from ._commands import parse_metadata
 from ._backend import backend
 
-__all__ = ('Forbidden', 'ConversionError', 'ConversionDirection',
+
+__all__ = ('Forbidden',
            'ChannelAlarm',
            'ChannelByte',
            'ChannelChar',
@@ -38,301 +37,8 @@ class Forbidden(CaprotoError):
     ...
 
 
-class ConversionError(CaprotoValueError):
-    ...
-
-
 class CannotExceedLimits(CaprotoValueError):
     ...
-
-
-class ConversionDirection(enum.Enum):
-    FROM_WIRE = enum.auto()
-    TO_WIRE = enum.auto()
-
-
-def encode_or_fail(s, encoding):
-    if isinstance(s, str):
-        if encoding is None:
-            raise ConversionError('String encoding required')
-        return s.encode(encoding)
-    elif isinstance(s, bytes):
-        return s
-
-    raise ConversionError('Expected string or bytes')
-
-
-def decode_or_fail(s, encoding):
-    if isinstance(s, bytes):
-        if encoding is None:
-            raise ConversionError('String encoding required')
-        return s.decode(encoding)
-    elif isinstance(s, str):
-        return s
-
-    raise ConversionError('Expected string or bytes')
-
-
-def _preprocess_enum_values(values, to_dtype, string_encoding, enum_strings):
-    if isinstance(values, (str, bytes)):
-        values = [values]
-
-    if enum_strings is None:
-        raise ConversionError('enum_strings not specified')
-
-    num_strings = len(enum_strings)
-
-    if to_dtype == ChannelType.STRING:
-        def enum_to_string(v):
-            if isinstance(v, bytes):
-                raise ConversionError('Enum strings must be integer or string')
-            elif isinstance(v, str):
-                if v not in enum_strings:
-                    raise ConversionError(f'Invalid enum string: {v!r}')
-                return v
-
-            if 0 <= v < num_strings:
-                return enum_strings[int(v)]
-            raise ConversionError(f'Invalid enum index: {v!r} '
-                                  f'count={num_strings}')
-        return [enum_to_string(v) for v in values]
-
-    def enum_to_int(v):
-        if isinstance(v, bytes):
-            raise ConversionError('Enum strings must be integer or string')
-        elif isinstance(v, str):
-            try:
-                return enum_strings.index(v)
-            except ValueError:
-                raise ConversionError(f'Invalid enum string: {v!r}')
-
-        if 0 <= v < num_strings:
-            return int(v)
-        raise ConversionError(f'Invalid enum index: {v!r} '
-                              f'count={num_strings}')
-
-    return [enum_to_int(v) for v in values]
-
-
-def _preprocess_char_from_wire(values, to_dtype, string_encoding, enum_strings):
-    'From wire: pre-process EPICS CHAR data for conversion to to_dtype'
-    if isinstance(values, list):
-        # This is from the wire, so it has to be a single value
-        bytes_from_wire = values[0]
-    else:
-        bytes_from_wire = values
-
-    bytes_from_wire = bytes_from_wire.tobytes()
-
-    if to_dtype in (ChannelType.STRING, ChannelType.CHAR):
-        if not string_encoding:
-            if to_dtype == ChannelType.STRING:
-                return [bytes_from_wire]
-            else:
-                return bytes_from_wire
-
-        values = bytes_from_wire.decode(string_encoding)
-        try:
-            return values[:values.index('\x00')]
-        except ValueError:
-            return values
-
-    # if not converting to a string, we need a list of numbers.
-    # b'bytes' -> [ord('b'), ord('y'), ...]
-    return list(bytes_from_wire)
-
-
-def _preprocess_char_to_wire(values, to_dtype, string_encoding, enum_strings):
-    'To wire: pre-process python-stored CHAR values for conversion to to_dtype'
-    if isinstance(values, list) and len(values) == 1:
-        values = values[0]
-
-    if to_dtype == ChannelType.STRING:
-        # NOTE: accurate, but results in very inefficient CA response
-        #       Bytes required: 40 * num_chars (i.e., 40 * len(values))
-        if isinstance(values, (str, bytes)):
-            # a length 3 char value is converted to 3 strings:
-            # b'abc' -> [b'a', b'b', b'c']
-            #  'abc' -> [b'a', b'b', b'c']
-            # this is, of course, different from returning b'abc', which would
-            # be converted to a single string on the wire.
-            return [bytes([v]) for v in encode_or_fail(values, string_encoding)]
-        else:
-            # list of numbers - these will be converted as follows:
-            # [1, 2, 3] -> ['1', '2', '3']
-            return values
-
-    # if not converting to a string, we need a list of numbers.
-    if isinstance(values, (str, bytes)):
-        if isinstance(values, str):
-            values = encode_or_fail(values, string_encoding)
-        # b'bytes' -> [ord('b'), ord('y'), ...]
-        return list(values)
-
-    # CHAR data is stored as integers
-    try:
-        values[0]
-    except TypeError:
-        # example: values = 5
-        return [values]
-    else:
-        # example: values = [5, 6, 7]
-        return values
-
-
-def _decode_string_list(values, string_encoding):
-    'List of bytes, strings, values -> list of decoded strings'
-    def get_value(v):
-        if isinstance(v, bytes):
-            if string_encoding:  # can have bytes in ChannelString
-                return v.decode(string_encoding)
-            return v
-        elif isinstance(v, str):
-            return v
-        else:
-            return str(v)
-    return [get_value(v) for v in values]
-
-
-def _encode_to_string_array(values, string_encoding):
-    'List of bytes, strings, values -> DbrStringArray'
-    def get_value(v):
-        if isinstance(v, bytes):
-            return v
-        elif isinstance(v, str):
-            return encode_or_fail(v, string_encoding)
-        else:
-            return encode_or_fail(str(v), string_encoding)
-    return DbrStringArray(get_value(v) for v in values)
-
-
-def _preprocess_string_from_wire(values, to_dtype, string_encoding,
-                                 enum_strings):
-    if to_dtype == ChannelType.STRING:
-        # caller will handle string decoding
-        return values
-
-    if to_dtype == ChannelType.ENUM:
-        values = [decode_or_fail(v, string_encoding)
-                  if isinstance(v, bytes)
-                  else v
-                  for v in values]
-
-        # conversion for when this is used: `caput enum_pv string_value`
-        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
-                                       string_encoding=string_encoding,
-                                       enum_strings=enum_strings)
-    elif to_dtype in native_int_types:
-        # TODO ca_test: for enums, string arrays seem to work, but not
-        # scalars?
-        return [int(v) for v in values]
-    elif to_dtype in native_float_types:
-        return [float(v) for v in values]
-
-
-def _preprocess_string_to_wire(values, to_dtype, string_encoding,
-                               enum_strings):
-    if isinstance(values, (str, bytes)):
-        values = [values]
-
-    # from here on, we are dealing with a list of strings/bytes
-    if to_dtype == ChannelType.STRING:
-        # caller will handle string encoding
-        return values
-    elif to_dtype == ChannelType.ENUM:
-        # for enums, decode bytes -> strings
-        values = [decode_or_fail(v, string_encoding)
-                  if isinstance(v, bytes)
-                  else v
-                  for v in values]
-        # conversion for when this is used: `caput enum_pv string_value`
-        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
-                                       string_encoding=string_encoding,
-                                       enum_strings=enum_strings)
-    elif to_dtype in native_int_types:
-        return [int(v) for v in values]
-    elif to_dtype in native_float_types:
-        return [float(v) for v in values]
-
-
-_custom_preprocess = {
-    (ChannelType.ENUM, ConversionDirection.TO_WIRE): _preprocess_enum_values,
-    (ChannelType.ENUM, ConversionDirection.FROM_WIRE): _preprocess_enum_values,
-    (ChannelType.CHAR, ConversionDirection.FROM_WIRE): _preprocess_char_from_wire,
-    (ChannelType.CHAR, ConversionDirection.TO_WIRE): _preprocess_char_to_wire,
-    (ChannelType.STRING, ConversionDirection.FROM_WIRE): _preprocess_string_from_wire,
-    (ChannelType.STRING, ConversionDirection.TO_WIRE): _preprocess_string_to_wire,
-}
-
-
-def convert_values(values, from_dtype, to_dtype, *, direction,
-                   string_encoding='latin-1', enum_strings=None,
-                   auto_byteswap=True):
-    '''Convert values from one ChannelType to another
-
-    Parameters
-    ----------
-    values :
-    from_dtype : caproto.ChannelType
-        The dtype of the values
-    to_dtype : caproto.ChannelType
-        The dtype to convert to
-    direction : caproto.ConversionDirection
-        Direction of conversion, from or to the wire
-    string_encoding : str, optional
-        The encoding to be used for strings
-    enum_strings : list, optional
-        List of enum strings, if available
-    auto_byteswap : bool, optional
-        If sending over the wire and using built-in arrays, the data should
-        first be byte-swapped to big-endian.
-    '''
-
-    if (from_dtype in (ChannelType.STSACK_STRING, ChannelType.CLASS_NAME) or
-            (to_dtype in (ChannelType.STSACK_STRING, ChannelType.CLASS_NAME))):
-        if from_dtype != to_dtype:
-            raise ConversionError('Cannot convert values for stsack_string or '
-                                  'class_name to other types')
-        return values
-
-    if to_dtype not in native_types or from_dtype not in native_types:
-        raise ConversionError('Expecting a native type')
-
-    if not isinstance(values, (str, bytes)):
-        try:
-            len(values)
-        except TypeError:
-            values = [values]
-
-    try:
-        preprocess = _custom_preprocess[(from_dtype, direction)]
-    except KeyError:
-        ...
-    else:
-        try:
-            values = preprocess(values=values, to_dtype=to_dtype,
-                                string_encoding=string_encoding,
-                                enum_strings=enum_strings)
-        except Exception as ex:
-            raise ConversionError() from ex
-
-        if to_dtype == ChannelType.STRING and isinstance(values, (str, bytes)):
-            values = [values]
-
-    if to_dtype == ChannelType.STRING:
-        if direction == ConversionDirection.TO_WIRE:
-            return _encode_to_string_array(values, string_encoding)
-        else:
-            return _decode_string_list(values, string_encoding)
-    elif to_dtype == ChannelType.CHAR:
-        if string_encoding and isinstance(values[0], str):
-            return values
-        elif not string_encoding and isinstance(values[0], bytes):
-            return values
-
-    byteswap = (auto_byteswap and direction == ConversionDirection.TO_WIRE)
-    return backend.python_to_epics(to_dtype, values, byteswap=byteswap,
-                                   convert_from=from_dtype)
 
 
 def dbr_metadata_to_dict(dbr_metadata, string_encoding):
@@ -621,12 +327,13 @@ class ChannelData:
             return class_name, b''
 
         native_to = native_type(data_type)
-        values = convert_values(values=self._data['value'],
-                                from_dtype=self.data_type,
-                                to_dtype=native_to,
-                                string_encoding=self.string_encoding,
-                                enum_strings=self._data.get('enum_strings'),
-                                direction=ConversionDirection.TO_WIRE)
+        values = backend.convert_values(
+            values=self._data['value'],
+            from_dtype=self.data_type,
+            to_dtype=native_to,
+            string_encoding=self.string_encoding,
+            enum_strings=self._data.get('enum_strings'),
+            direction=ConversionDirection.TO_WIRE)
 
         # for native types, there is no dbr metadata - just data
         if data_type in native_types:
@@ -673,12 +380,12 @@ class ChannelData:
 
         timestamp = time.time()
         native_from = native_type(data_type)
-        value = convert_values(values=data, from_dtype=native_from,
-                               to_dtype=self.data_type,
-                               string_encoding=self.string_encoding,
-                               enum_strings=getattr(self, 'enum_strings',
-                                                    None),
-                               direction=ConversionDirection.FROM_WIRE)
+        value = backend.convert_values(
+            values=data, from_dtype=native_from,
+            to_dtype=self.data_type,
+            string_encoding=self.string_encoding,
+            enum_strings=getattr(self, 'enum_strings', None),
+            direction=ConversionDirection.FROM_WIRE)
 
         try:
             modified_value = await self.verify_value(value)
@@ -808,13 +515,13 @@ class ChannelData:
             dt = (self.data_type
                   if self.data_type != ChannelType.ENUM
                   else ChannelType.INT)
-            values = convert_values(values=[data.get(key, 0)
-                                            for key in convert_attrs],
-                                    from_dtype=dt,
-                                    to_dtype=native_type(to_type),
-                                    string_encoding=self.string_encoding,
-                                    direction=ConversionDirection.TO_WIRE,
-                                    auto_byteswap=False)
+            values = backend.convert_values(
+                values=[data.get(key, 0) for key in convert_attrs],
+                from_dtype=dt,
+                to_dtype=native_type(to_type),
+                string_encoding=self.string_encoding,
+                direction=ConversionDirection.TO_WIRE,
+                auto_byteswap=False)
             if isinstance(values, backend.array_types):
                 values = values.tolist()
             for attr, value in zip(convert_attrs, values):

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -51,98 +51,6 @@ class ConversionDirection(enum.Enum):
     TO_WIRE = enum.auto()
 
 
-def _convert_enum_values(values, to_dtype, string_encoding, enum_strings,
-                         direction):
-    if enum_strings is None:
-        raise ConversionError('enum_strings not specified')
-
-    num_strings = len(enum_strings)
-
-    if to_dtype == ChannelType.STRING:
-        def get_value(v):
-            if isinstance(v, bytes):
-                raise ConversionError('Enum strings must be integer or string')
-
-            if isinstance(v, str):
-                if v not in enum_strings:
-                    raise ConversionError(f'Invalid enum string: {v!r}')
-                return v
-
-            if 0 <= v < num_strings:
-                return enum_strings[v]
-            raise ConversionError(f'Invalid enum index: {v!r} '
-                                  f'count={num_strings}')
-    else:
-        def get_value(v):
-            if isinstance(v, bytes):
-                raise ConversionError('Enum strings must be integer or string')
-
-            if isinstance(v, str):
-                try:
-                    return enum_strings.index(v)
-                except ValueError:
-                    raise ConversionError(f'Invalid enum string: {v!r}')
-
-            if 0 <= v < num_strings:
-                return v
-            raise ConversionError(f'Invalid enum index: {v!r} '
-                                  f'count={num_strings}')
-
-    return [get_value(v) for v in values]
-
-
-def _convert_char_values(values, to_dtype, string_encoding, enum_strings,
-                         direction):
-    if isinstance(values, list) and len(values) == 1:
-        # exception to handling things as lists...
-        values = values[0]
-
-    if direction == ConversionDirection.FROM_WIRE:
-        values = values.tobytes()  # b''.join(values)
-
-    if to_dtype == ChannelType.STRING:
-        if direction == ConversionDirection.TO_WIRE:
-            # NOTE: accurate, but results in very inefficient CA response
-            #       40 * len(values)
-            if isinstance(values, str):
-                return [bytes([v])
-                        for v in encode_or_fail(values, string_encoding)]
-            elif isinstance(values, bytes):
-                return [bytes([v]) for v in values]
-            else:
-                # list of numbers
-                return values
-        else:
-            return [decode_or_fail(values, string_encoding)]
-    elif to_dtype == ChannelType.CHAR:
-        if direction == ConversionDirection.FROM_WIRE and string_encoding:
-            values = values.decode(string_encoding)
-            try:
-                return [values[:values.index('\x00')]]
-            except ValueError:
-                return [values]
-
-    # if not converting to a string, we need a list of numbers.
-    if isinstance(values, bytes):
-        # b'bytes' -> [ord('b'), ord('y'), ...]
-        values = list(values)
-    elif isinstance(values, str):
-        values = encode_or_fail(values, string_encoding)
-        # b'bytes' -> [ord('b'), ord('y'), ...]
-        values = list(values)
-    else:
-        # list of bytes already
-        ...
-
-    try:
-        # TODO lazy check
-        values[0]
-    except TypeError:
-        return [values]
-    else:
-        return values
-
-
 def encode_or_fail(s, encoding):
     if isinstance(s, str):
         if encoding is None:
@@ -165,26 +73,155 @@ def decode_or_fail(s, encoding):
     raise ConversionError('Expected string or bytes')
 
 
-def _convert_string_values(values, to_dtype, string_encoding, enum_strings,
-                           direction):
+def _preprocess_enum_values(values, to_dtype, string_encoding, enum_strings):
+    if isinstance(values, (str, bytes)):
+        values = [values]
+
+    if enum_strings is None:
+        raise ConversionError('enum_strings not specified')
+
+    num_strings = len(enum_strings)
+
     if to_dtype == ChannelType.STRING:
+        def enum_to_string(v):
+            if isinstance(v, bytes):
+                raise ConversionError('Enum strings must be integer or string')
+            elif isinstance(v, str):
+                if v not in enum_strings:
+                    raise ConversionError(f'Invalid enum string: {v!r}')
+                return v
+
+            if 0 <= v < num_strings:
+                return enum_strings[int(v)]
+            raise ConversionError(f'Invalid enum index: {v!r} '
+                                  f'count={num_strings}')
+        return [enum_to_string(v) for v in values]
+
+    def enum_to_int(v):
+        if isinstance(v, bytes):
+            raise ConversionError('Enum strings must be integer or string')
+        elif isinstance(v, str):
+            try:
+                return enum_strings.index(v)
+            except ValueError:
+                raise ConversionError(f'Invalid enum string: {v!r}')
+
+        if 0 <= v < num_strings:
+            return int(v)
+        raise ConversionError(f'Invalid enum index: {v!r} '
+                              f'count={num_strings}')
+
+    return [enum_to_int(v) for v in values]
+
+
+def _preprocess_char_from_wire(values, to_dtype, string_encoding, enum_strings):
+    'From wire: pre-process EPICS CHAR data for conversion to to_dtype'
+    if isinstance(values, list):
+        # This is from the wire, so it has to be a single value
+        bytes_from_wire = values[0]
+    else:
+        bytes_from_wire = values
+
+    bytes_from_wire = bytes_from_wire.tobytes()
+
+    if to_dtype in (ChannelType.STRING, ChannelType.CHAR):
+        if not string_encoding:
+            if to_dtype == ChannelType.STRING:
+                return [bytes_from_wire]
+            else:
+                return bytes_from_wire
+
+        values = bytes_from_wire.decode(string_encoding)
+        try:
+            return values[:values.index('\x00')]
+        except ValueError:
+            return values
+
+    # if not converting to a string, we need a list of numbers.
+    # b'bytes' -> [ord('b'), ord('y'), ...]
+    return list(bytes_from_wire)
+
+
+def _preprocess_char_to_wire(values, to_dtype, string_encoding, enum_strings):
+    'To wire: pre-process python-stored CHAR values for conversion to to_dtype'
+    if isinstance(values, list) and len(values) == 1:
+        values = values[0]
+
+    if to_dtype == ChannelType.STRING:
+        # NOTE: accurate, but results in very inefficient CA response
+        #       Bytes required: 40 * num_chars (i.e., 40 * len(values))
+        if isinstance(values, (str, bytes)):
+            # a length 3 char value is converted to 3 strings:
+            # b'abc' -> [b'a', b'b', b'c']
+            #  'abc' -> [b'a', b'b', b'c']
+            # this is, of course, different from returning b'abc', which would
+            # be converted to a single string on the wire.
+            return [bytes([v]) for v in encode_or_fail(values, string_encoding)]
+        else:
+            # list of numbers - these will be converted as follows:
+            # [1, 2, 3] -> ['1', '2', '3']
+            return values
+
+    # if not converting to a string, we need a list of numbers.
+    if isinstance(values, (str, bytes)):
+        if isinstance(values, str):
+            values = encode_or_fail(values, string_encoding)
+        # b'bytes' -> [ord('b'), ord('y'), ...]
+        return list(values)
+
+    # CHAR data is stored as integers
+    try:
+        values[0]
+    except TypeError:
+        # example: values = 5
+        return [values]
+    else:
+        # example: values = [5, 6, 7]
         return values
 
-    if (direction == ConversionDirection.FROM_WIRE or
-            to_dtype == ChannelType.ENUM):
-        # from the wire (or for enums), decode bytes -> strings
+
+def _decode_string_list(values, string_encoding):
+    'List of bytes, strings, values -> list of decoded strings'
+    def get_value(v):
+        if isinstance(v, bytes):
+            if string_encoding:  # can have bytes in ChannelString
+                return v.decode(string_encoding)
+            return v
+        elif isinstance(v, str):
+            return v
+        else:
+            return str(v)
+    return [get_value(v) for v in values]
+
+
+def _encode_to_string_array(values, string_encoding):
+    'List of bytes, strings, values -> DbrStringArray'
+    def get_value(v):
+        if isinstance(v, bytes):
+            return v
+        elif isinstance(v, str):
+            return encode_or_fail(v, string_encoding)
+        else:
+            return encode_or_fail(str(v), string_encoding)
+    return DbrStringArray(get_value(v) for v in values)
+
+
+def _preprocess_string_from_wire(values, to_dtype, string_encoding,
+                                 enum_strings):
+    if to_dtype == ChannelType.STRING:
+        # caller will handle string decoding
+        return values
+
+    if to_dtype == ChannelType.ENUM:
         values = [decode_or_fail(v, string_encoding)
                   if isinstance(v, bytes)
                   else v
                   for v in values]
 
-    if to_dtype == ChannelType.ENUM:
-        # TODO: this is used where caput('enum', 'string_value')
-        #       i.e., putting a string to an enum
-        return _convert_enum_values(values, to_dtype=ChannelType.INT,
-                                    string_encoding=string_encoding,
-                                    enum_strings=enum_strings,
-                                    direction=direction)
+        # conversion for when this is used: `caput enum_pv string_value`
+        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
+                                       string_encoding=string_encoding,
+                                       enum_strings=enum_strings)
     elif to_dtype in native_int_types:
         # TODO ca_test: for enums, string arrays seem to work, but not
         # scalars?
@@ -193,10 +230,38 @@ def _convert_string_values(values, to_dtype, string_encoding, enum_strings,
         return [float(v) for v in values]
 
 
-_custom_conversions = {
-    ChannelType.ENUM: _convert_enum_values,
-    ChannelType.CHAR: _convert_char_values,
-    ChannelType.STRING: _convert_string_values,
+def _preprocess_string_to_wire(values, to_dtype, string_encoding,
+                               enum_strings):
+    if isinstance(values, (str, bytes)):
+        values = [values]
+
+    # from here on, we are dealing with a list of strings/bytes
+    if to_dtype == ChannelType.STRING:
+        # caller will handle string encoding
+        return values
+    elif to_dtype == ChannelType.ENUM:
+        # for enums, decode bytes -> strings
+        values = [decode_or_fail(v, string_encoding)
+                  if isinstance(v, bytes)
+                  else v
+                  for v in values]
+        # conversion for when this is used: `caput enum_pv string_value`
+        return _preprocess_enum_values(values, to_dtype=ChannelType.INT,
+                                       string_encoding=string_encoding,
+                                       enum_strings=enum_strings)
+    elif to_dtype in native_int_types:
+        return [int(v) for v in values]
+    elif to_dtype in native_float_types:
+        return [float(v) for v in values]
+
+
+_custom_preprocess = {
+    (ChannelType.ENUM, ConversionDirection.TO_WIRE): _preprocess_enum_values,
+    (ChannelType.ENUM, ConversionDirection.FROM_WIRE): _preprocess_enum_values,
+    (ChannelType.CHAR, ConversionDirection.FROM_WIRE): _preprocess_char_from_wire,
+    (ChannelType.CHAR, ConversionDirection.TO_WIRE): _preprocess_char_to_wire,
+    (ChannelType.STRING, ConversionDirection.FROM_WIRE): _preprocess_string_from_wire,
+    (ChannelType.STRING, ConversionDirection.TO_WIRE): _preprocess_string_to_wire,
 }
 
 
@@ -233,55 +298,36 @@ def convert_values(values, from_dtype, to_dtype, *, direction,
     if to_dtype not in native_types or from_dtype not in native_types:
         raise ConversionError('Expecting a native type')
 
-    if isinstance(values, (str, bytes)):
-        values = [values]
-    else:
+    if not isinstance(values, (str, bytes)):
         try:
             len(values)
         except TypeError:
-            values = (values, )
+            values = [values]
 
     try:
-        convert_func = _custom_conversions[from_dtype]
+        preprocess = _custom_preprocess[(from_dtype, direction)]
     except KeyError:
         ...
     else:
         try:
-            values = convert_func(values=values, to_dtype=to_dtype,
-                                  string_encoding=string_encoding,
-                                  enum_strings=enum_strings,
-                                  direction=direction)
+            values = preprocess(values=values, to_dtype=to_dtype,
+                                string_encoding=string_encoding,
+                                enum_strings=enum_strings)
         except Exception as ex:
             raise ConversionError() from ex
 
+        if to_dtype == ChannelType.STRING and isinstance(values, (str, bytes)):
+            values = [values]
+
     if to_dtype == ChannelType.STRING:
         if direction == ConversionDirection.TO_WIRE:
-            string_target = bytes
+            return _encode_to_string_array(values, string_encoding)
         else:
-            string_target = str
-
-        if string_target is str:
-            def get_value(v):
-                if isinstance(v, bytes):
-                    if string_encoding:  # can have bytes in ChannelString
-                        return v.decode(string_encoding)
-                    return v
-                elif isinstance(v, str):
-                    return v
-                else:
-                    return str(v)
-            return [get_value(v) for v in values]
-
-        def get_value(v):
-            if isinstance(v, bytes):
-                return v
-            elif isinstance(v, str):
-                return encode_or_fail(v, string_encoding)
-            else:
-                return encode_or_fail(str(v), string_encoding)
-        return DbrStringArray(get_value(v) for v in values)
+            return _decode_string_list(values, string_encoding)
     elif to_dtype == ChannelType.CHAR:
         if string_encoding and isinstance(values[0], str):
+            return values
+        elif not string_encoding and isinstance(values[0], bytes):
             return values
 
     byteswap = (auto_byteswap and direction == ConversionDirection.TO_WIRE)
@@ -966,19 +1012,28 @@ class ChannelByte(ChannelNumeric):
     data_type = ChannelType.CHAR
 
     def __init__(self, *, value=None, max_length=100, string_encoding=None,
+                 strip_null_terminator=True,
                  **kwargs):
         if string_encoding is not None:
             raise ValueError('ChannelByte cannot have a string encoding')
 
         super().__init__(value=value, string_encoding=None, **kwargs)
+        self.strip_null_terminator = strip_null_terminator
         self.max_length = max_length
 
     async def verify_value(self, data):
-        if isinstance(data, list):
-            data = data[0]
+        if isinstance(data, (list, ) + backend.array_types):
+            if not data:
+                return b''
+            elif len(data) == 1:
+                data = data[0]
+            else:
+                data = b''.join(map(bytes, ([v] for v in data)))
+
+        if self.strip_null_terminator:
+            data = data.rstrip(b'\x00')
 
         if isinstance(data, str):
-            # return list(data.encode('ascii'))  # TODO: just reject?
             raise ValueError('ChannelByte does not accept decoded strings')
 
         return data
@@ -990,9 +1045,8 @@ class ChannelChar(ChannelData):
 
     def __init__(self, *, value=None, max_length=100,
                  string_encoding='latin-1', **kwargs):
-        if isinstance(value, (str, bytes)):
-            if isinstance(value, bytes):
-                value = value.decode(string_encoding)
+        if isinstance(value, bytes):
+            value = value.decode(string_encoding)
 
         super().__init__(value=value, **kwargs)
         self.max_length = max_length

--- a/caproto/_numpy_backend.py
+++ b/caproto/_numpy_backend.py
@@ -1,5 +1,5 @@
 import ctypes
-from ._backend import Backend, register_backend
+from ._backend import Backend, register_backend, convert_values
 from ._dbr import (ChannelType, DbrStringArray, native_types, DBR_TYPES)
 
 try:
@@ -72,6 +72,7 @@ def _setup():
                    type_map=type_map,
                    epics_to_python=epics_to_python,
                    python_to_epics=python_to_epics,
+                   convert_values=convert_values,
                    )
 
 

--- a/caproto/_numpy_backend.py
+++ b/caproto/_numpy_backend.py
@@ -57,6 +57,9 @@ def python_to_epics(dtype, values, *, byteswap=True, convert_from=None):
     elif dtype == ChannelType.CHAR:
         if isinstance(values, bytes):
             return values
+        if isinstance(values[0], bytes):
+            assert len(values) == 1, "expected b'...', [b'...'], or [...]"
+            return values[0]
 
     return np.asarray(values).astype(type_map[dtype])
 

--- a/caproto/_numpy_backend.py
+++ b/caproto/_numpy_backend.py
@@ -54,6 +54,9 @@ def python_to_epics(dtype, values, *, byteswap=True, convert_from=None):
     # NOTE: ignoring byteswap, storing everything as big-endian
     if dtype == ChannelType.STRING:
         return DbrStringArray(values).tobytes()
+    elif dtype == ChannelType.CHAR:
+        if isinstance(values, bytes):
+            return values
 
     return np.asarray(values).astype(type_map[dtype])
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -56,6 +56,7 @@ __all__ = (  # noqa F822
     'CaprotoNotImplementedError',
     'CaprotoValueError',
     'CaprotoTypeError',
+    'CaprotoConversionError',
     'CaprotoRuntimeError',
     'ErrorResponseReceived',
     'SendAllRetry',
@@ -113,6 +114,11 @@ class States(_SimpleReprEnum):
     NEED_DATA = enum.auto()
 
 
+class ConversionDirection(_SimpleReprEnum):
+    FROM_WIRE = enum.auto()
+    TO_WIRE = enum.auto()
+
+
 globals().update(
     {token: getattr(_enum, token)
      for _enum in [Role, Direction, States]
@@ -155,6 +161,10 @@ class CaprotoNotImplementedError(NotImplementedError, CaprotoError):
 
 
 class CaprotoValueError(ValueError, CaprotoError):
+    ...
+
+
+class CaprotoConversionError(CaprotoValueError):
     ...
 
 

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -2,7 +2,6 @@
 # as three top-level functions: read, write, subscribe. They are comparatively
 # simple and naive, with no caching or concurrency, and therefore less
 # performant but more robust.
-from collections import Iterable
 import inspect
 import getpass
 import logging

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -437,10 +437,6 @@ def block(*subscriptions, duration=None, timeout=1, force_int_enums=False,
 
 
 def _write(chan, data, metadata, timeout, data_type, notify):
-    if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
-        data = [data]
-    if data and isinstance(data[0], str):
-        data = [val.encode('latin-1') for val in data]
     logger.debug("Detected native data_type %r.", chan.native_data_type)
     # abundance of caution
     ntype = field_types['native'][chan.native_data_type]

--- a/caproto/tests/epics_test_utils.py
+++ b/caproto/tests/epics_test_utils.py
@@ -53,15 +53,7 @@ async def run_epics_base_binary(backend, *args, max_attempts=3):
         return raw_stdout, raw_stderr
 
     if backend == 'curio':
-        if sys.platform == 'win32':
-            raw_stdout, raw_stderr = await curio.run_in_thread(runner)
-        else:
-            p = curio.subprocess.Popen(args, env=env,
-                                       stdout=curio.subprocess.PIPE,
-                                       stderr=curio.subprocess.PIPE)
-            await p.wait()
-            raw_stdout = await p.stdout.read()
-            raw_stderr = await p.stderr.read()
+        raw_stdout, raw_stderr = await curio.run_in_thread(runner)
     elif backend == 'trio':
         raw_stdout, raw_stderr = await trio.run_sync_in_worker_thread(runner)
     elif backend == 'asyncio':

--- a/caproto/tests/test_data_conversion.py
+++ b/caproto/tests/test_data_conversion.py
@@ -301,9 +301,9 @@ char_from_wire_tests = [
     [CHAR, FLOAT, b'\x05', [5.0], no_encoding],
     [CHAR, ENUM, b'\x01', [1], no_encoding],
     # like channelbytes (no encoding)
-    [CHAR, CHAR, b'abc', list(b'abc'), no_encoding],
+    [CHAR, CHAR, b'abc', b'abc', no_encoding],
     # like channelchar (with encoding)
-    [CHAR, CHAR, b'abc', ['abc'], ascii_encoding],
+    [CHAR, CHAR, b'abc', 'abc', ascii_encoding],
     [CHAR, LONG, b"x", [ord('x')], no_encoding],
     [CHAR, DOUBLE, b"x", [ord('x')], no_encoding],
 ]

--- a/caproto/tests/test_data_conversion.py
+++ b/caproto/tests/test_data_conversion.py
@@ -3,7 +3,7 @@ from inspect import isclass
 
 import pytest
 
-from .._data import convert_values, ConversionDirection
+from .._utils import ConversionDirection
 from .._dbr import ChannelType, DbrStringArray
 from .. import backend
 from .conftest import (array_types, assert_array_almost_equal)
@@ -30,14 +30,15 @@ CLASS_NAME = ChannelType.CLASS_NAME
 @pytest.mark.parametrize('ntype', (STSACK_STRING, CLASS_NAME))
 def test_special_types(backends, ntype):
     in_value = expected_value = 0.2
-    out_value = convert_values(values=in_value, from_dtype=ntype,
-                               to_dtype=ntype, direction=FROM_WIRE)
+    out_value = backend.convert_values(
+        values=in_value, from_dtype=ntype, to_dtype=ntype, direction=FROM_WIRE)
 
     assert out_value == expected_value
 
     with pytest.raises(ValueError):
-        out_value = convert_values(values=in_value, from_dtype=ntype,
-                                   to_dtype=STRING, direction=FROM_WIRE)
+        out_value = backend.convert_values(
+            values=in_value, from_dtype=ntype, to_dtype=STRING,
+            direction=FROM_WIRE)
 
 
 def run_conversion_test(values, from_dtype, to_dtype, expected,
@@ -48,12 +49,10 @@ def run_conversion_test(values, from_dtype, to_dtype, expected,
         print(f'Convert: {from_dtype.name} {values!r} -> {to_dtype.name} '
               f'(str encoding: {string_encoding})')
         print(f'Expecting: {expected!r}')
-        converted = convert_values(values, from_dtype=from_dtype,
-                                   to_dtype=to_dtype,
-                                   string_encoding=string_encoding,
-                                   enum_strings=enum_strings,
-                                   direction=direction,
-                                   auto_byteswap=False)
+        converted = backend.convert_values(
+            values, from_dtype=from_dtype, to_dtype=to_dtype,
+            string_encoding=string_encoding, enum_strings=enum_strings,
+            direction=direction, auto_byteswap=False)
         print(f'Converted: {converted!r}')
         return converted
 

--- a/caproto/tests/test_server.py
+++ b/caproto/tests/test_server.py
@@ -9,7 +9,7 @@ import caproto as ca
 from caproto import ChannelType
 from .epics_test_utils import (run_caget, run_caput)
 from .conftest import array_types, run_example_ioc
-from caproto.sync.client import write, ErrorResponseReceived
+from caproto.sync.client import write, read, ErrorResponseReceived
 
 
 caget_checks = sum(
@@ -280,3 +280,13 @@ def test_limits_enforced(request, prefix):
         write(pv, 3.09, notify=True)  # beyond limit
     with pytest.raises(ErrorResponseReceived):
         write(pv, 3.181, notify=True)  # beyond limit
+
+
+def test_char_write(request, prefix):
+    pv = f'{prefix}chararray'
+    run_example_ioc('caproto.ioc_examples.type_varieties', request=request,
+                    args=['--prefix', prefix],
+                    pv_to_check=pv)
+    write(pv, b'testtesttest', notify=True)
+    response = read(pv)
+    assert ''.join(chr(c) for c in response.data) == 'testtesttest'

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -10,7 +10,6 @@
 # The VirtualCircuit has:
 # - ThreadPoolExecutor for processing user callbacks on read, write, subscribe
 import array
-from collections import Iterable
 import concurrent.futures
 import errno
 import functools

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1491,10 +1491,6 @@ class PV:
             Requested number of values. Default is the channel's native data
             count.
         """
-        if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
-            data = [data]
-        if len(data) and isinstance(data[0], str):
-            data = [val.encode(STR_ENC) for val in data]
         if notify is None:
             notify = (wait or callback is not None)
         ioid = self.circuit_manager._ioid_counter()
@@ -1908,10 +1904,6 @@ class Batch:
             Requested number of values. Default is the channel's native data
             count.
         """
-        if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
-            data = [data]
-        if len(data) and isinstance(data[0], str):
-            data = [val.encode(STR_ENC) for val in data]
         ioid = pv.circuit_manager._ioid_counter()
         command = pv.channel.write(data=data,
                                    ioid=ioid,


### PR DESCRIPTION
Initial commit does some minor cleaning of conversion code, fixes testing on byte arrays.
Hopefully a bit more clear?

2nd commit is up for consideration. I think we need to centralize _all_ conversion functions. First thought was to move them to `caproto._backend` to start with. I could easily be convinced to do it a different way, though...