### PR TITLE
TST: Use very generous timeouts in threading tests.

### DIFF
--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -23,7 +23,7 @@ from .conftest import default_teardown_module as teardown_module  # noqa
 
 def test_go_idle(context, ioc):
     pv, = context.get_pvs(ioc.pvs['str'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     assert pv.connected
     print(pv.read())
 
@@ -38,7 +38,7 @@ def test_go_idle(context, ioc):
 
 def test_context_disconnect_is_terminal(context, ioc):
     pv, = context.get_pvs(ioc.pvs['str'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     assert pv.connected
 
     pv.read()
@@ -51,7 +51,7 @@ def test_context_disconnect_is_terminal(context, ioc):
 
 def test_put_complete(backends, context, ioc):
     pv, = context.get_pvs(ioc.pvs['int'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     assert pv.connected
 
     # start in a known initial state
@@ -86,7 +86,7 @@ def test_put_complete(backends, context, ioc):
 
 def test_specified_port(monkeypatch, context, ioc):
     pv, = context.get_pvs(ioc.pvs['float'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
 
     circuit = pv.circuit_manager.circuit
     address_list = list(caproto.get_address_list())
@@ -171,7 +171,7 @@ def test_server_crash(context, ioc_factory):
 
     # Wait for everything to connect.
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     # Wait to confirm that the subscription produced a response.
     while not collector:
         time.sleep(0.05)
@@ -184,7 +184,7 @@ def test_server_crash(context, ioc_factory):
     # Start the ioc again (it has the same prefix).
     second_ioc = ioc_factory()
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
         assert pv.connected
     # Wait to confirm that the subscription produced a new response.
     while not collector:
@@ -199,7 +199,7 @@ def test_subscriptions(ioc, context):
     cntx = context
 
     pv, = cntx.get_pvs(ioc.pvs['int'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
 
     monitor_values = []
 
@@ -246,7 +246,7 @@ def test_many_priorities_same_name(ioc, context):
     for priority in range(0, 10, 9):
         pvs[priority], = context.get_pvs(pv_name, priority=priority)
     for pv in pvs.values():
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
 
 
 def test_two_iocs_one_pv(ioc_factory, context):
@@ -258,7 +258,7 @@ def test_two_iocs_one_pv(ioc_factory, context):
     assert first_ioc.pvs == second_ioc.pvs
     pv_name, *_others = first_ioc.pvs.values()
     pv, = context.get_pvs(pv_name)
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     time.sleep(0.2)  # By now both IOC will have answered.
     # Exercise it a bit as a smoke test of sorts.
     pv.read()
@@ -272,7 +272,7 @@ def test_two_iocs_one_pv(ioc_factory, context):
 def test_multiple_subscriptions_one_server(ioc, context):
     pvs = context.get_pvs(*ioc.pvs.values())
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     collector = collections.defaultdict(list)
 
     def collect(sub, response):
@@ -291,7 +291,7 @@ def test_multiple_subscriptions_one_server(ioc, context):
 def test_subscription_objects_are_reused(ioc, context):
     pv, = context.get_pvs(ioc.pvs['int'])
 
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     sub = pv.subscribe(data_type=0)
     sub_redundant = pv.subscribe(data_type=0)  # should return `sub` again
     sub_different = pv.subscribe(data_type=1)  # different args -- new sub
@@ -315,7 +315,7 @@ def test_subscription_objects_are_reused(ioc, context):
 
 def test_unsubscribe_all(ioc, context):
     pv, = context.get_pvs(ioc.pvs['int'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     sub0 = pv.subscribe(data_type=0)
     sub1 = pv.subscribe(data_type=1)
 
@@ -345,7 +345,7 @@ def test_unsubscribe_all(ioc, context):
 
 def test_timeout(ioc, context):
     pv, = context.get_pvs(ioc.pvs['int'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
 
     # Check that timeout=None is allowed.
     pv.write((1, ), timeout=None)
@@ -436,7 +436,7 @@ def test_multithreaded_many_get_pvs(ioc, context, thread_count,
                                     multi_iterations):
     def _test(thread_id):
         pv, = context.get_pvs(ioc.pvs['int'])
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
 
         pvs[thread_id] = pv
         return pv.connected
@@ -451,7 +451,7 @@ def test_multithreaded_many_get_pvs(ioc, context, thread_count,
 def test_multithreaded_many_wait_for_connection(ioc, context, thread_count,
                                                 multi_iterations):
     def _test(thread_id):
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
         return pv.connected
 
     pv, = context.get_pvs(ioc.pvs['int'])
@@ -464,7 +464,7 @@ def test_multithreaded_many_read(ioc, context, thread_count,
                                  multi_iterations):
     def _test(thread_id):
         data_id = thread_id % max(data_types)
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
         value = pv.read(data_type=data_types[data_id])
         values[data_id] = value
         return (data_id, value)
@@ -485,7 +485,7 @@ def test_multithreaded_many_read(ioc, context, thread_count,
 def test_multithreaded_many_write(ioc, context, thread_count,
                                   multi_iterations):
     def _test(thread_id):
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
         ret = pv.write(data=[thread_id], wait=True)
         time.sleep(0.2)  # Wait for EventAddResponse to be received, processed.
         return ret
@@ -548,7 +548,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
     sub_ended_barrier = threading.Barrier(parties=thread_count + 1)
 
     pv, = context.get_pvs(ioc.pvs['int'])
-    pv.wait_for_connection()
+    pv.wait_for_connection(timeout=10)
     initial_value = pv.read().data.tolist()[0]
 
     print()
@@ -571,7 +571,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
 def test_batch_read(context, ioc):
     pvs = context.get_pvs(ioc.pvs['int'], ioc.pvs['int2'], ioc.pvs['int3'])
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     results = {}
 
     def stash_result(name, response):
@@ -587,7 +587,7 @@ def test_batch_read(context, ioc):
 def test_batch_write(context, ioc):
     pvs = context.get_pvs(ioc.pvs['int'], ioc.pvs['int2'], ioc.pvs['int3'])
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     results = {}
 
     def stash_result(name, response):
@@ -605,7 +605,7 @@ def test_batch_write(context, ioc):
 def test_batch_write_no_callback(context, ioc):
     pvs = context.get_pvs(ioc.pvs['int'], ioc.pvs['int2'], ioc.pvs['int3'])
     for pv in pvs:
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     with Batch() as b:
         for pv in pvs:
             b.write(pv, [4407])
@@ -617,7 +617,7 @@ def test_batch_write_no_callback(context, ioc):
 def test_write_accepts_scalar(context, ioc):
     int_pv, str_pv = context.get_pvs(ioc.pvs['int'], ioc.pvs['str'])
     for pv in (int_pv, str_pv):
-        pv.wait_for_connection()
+        pv.wait_for_connection(timeout=10)
     int_pv.write(17, wait=True)
     assert list(int_pv.read().data) == [17]
     str_pv.write('caprotoss', wait=True)


### PR DESCRIPTION
Example of a false failure that this is meant to address:

```
_______________________ test_specified_port[epics-base] ________________________
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fa311bc7f28>
context = <Context searches_pending=1 circuits=0 pvs=1 idle=0>
ioc = namespace(name='Waveform and standard record IOC', prefix='e9a34ecc:', process=<subprocess.Popen object at 0x7fa30e79a...m', 'str': 'e9a34ecc:str', 'int': 'e9a34ecc:int', 'int2': 'e9a34ecc:int2', 'int3': 'e9a34ecc:int3'}, type='epics-base')
    def test_specified_port(monkeypatch, context, ioc):
        pv, = context.get_pvs(ioc.pvs['float'])
>       pv.wait_for_connection()
caproto/tests/test_threading_client.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

<snip>

caproto/threading/client.py:92: TimeoutError
```

This may seem like a wildly high value for a timeout, but Travis-CI can be anomalously slow sometimes, and we have learned that other projects with large test suites also find themselves applying very generous timeouts.