### PR TITLE
REF: replace (deprecated) trio queues with trio memory channels

### DIFF
--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -92,7 +92,7 @@ class VirtualCircuit(_VirtualCircuit):
         self._sq_task = None
         self._write_tasks = ()
 
-    async def get_from_sub_queue_with_timeout(self, timeout):
+    async def get_from_sub_queue(self, timeout=None):
         # Timeouts work very differently between our server implementations,
         # so we do this little stub in its own method.
         fut = asyncio.ensure_future(self.subscription_queue.get())

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -91,10 +91,13 @@ class VirtualCircuit(_VirtualCircuit):
         async with self.new_command_condition:
             await self.new_command_condition.notify_all()
 
-    async def get_from_sub_queue_with_timeout(self, timeout):
+    async def get_from_sub_queue(self, timeout=None):
         # Timeouts work very differently between our server implementations,
         # so we do this little stub in its own method.
         # Returns weakref(EventAddResponse) or None
+        if timeout is None:
+            return await self.subscription_queue.get()
+
         return await curio.ignore_after(timeout, self.subscription_queue.get)
 
 

--- a/caproto/examples/trio_client_simple.py
+++ b/caproto/examples/trio_client_simple.py
@@ -4,8 +4,7 @@ import trio
 from caproto.trio.client import (SharedBroadcaster, Context)
 
 
-async def main(pv1="XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL",
-               pv2="XF:31IDA-OP{Tbl-Ax:X2}Mtr.VAL"):
+async def main(pv1="simple:A", pv2="simple:B"):
     '''Simple example which connects to two motorsim PVs (by default).
 
     It tests reading, writing, and subscriptions.

--- a/caproto/examples/trio_client_simple.py
+++ b/caproto/examples/trio_client_simple.py
@@ -5,7 +5,13 @@ from caproto.trio.client import (SharedBroadcaster, Context)
 
 
 async def main(pv1="simple:A", pv2="simple:B"):
-    '''Simple example which connects to two motorsim PVs (by default).
+    '''Simple example which connects to two PVs on the simple IOC (by default).
+
+    Start the simple IOC like so:
+
+    python -m caproto.ioc_examples.simple
+
+    and then run this example.
 
     It tests reading, writing, and subscriptions.
     '''

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -175,7 +175,7 @@ class VirtualCircuit:
             return
 
         if command is ca.DISCONNECTED:
-            raise DisconnectedCircuit()
+            raise DisconnectedCircuit
 
         try:
             response = await self._process_command(command)

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -136,7 +136,7 @@ class VirtualCircuit:
         """
         try:
             self.circuit.process_command(command)
-        except ca.RemoteProtocolError as ex:
+        except ca.RemoteProtocolError:
             if hasattr(command, 'sid'):
                 sid = command.sid
                 cid = self.circuit.channels_sid[sid].cid

--- a/caproto/tests/test_examples.py
+++ b/caproto/tests/test_examples.py
@@ -1,4 +1,5 @@
 import curio
+import functools
 import os
 import pytest
 import trio
@@ -30,7 +31,11 @@ def test_curio_client_example():
                     reason='win32 motorsim IOC')
 def test_trio_client_example():
     from caproto.examples.trio_client_simple import main
-    trio.run(main)
+    main_with_motorsim = functools.partial(
+        main,
+        pv1="XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL",
+        pv2="XF:31IDA-OP{Tbl-Ax:X2}Mtr.VAL")
+    trio.run(main_with_motorsim)
 
 
 def test_thread_client_example(curio_server):

--- a/caproto/trio/server.py
+++ b/caproto/trio/server.py
@@ -1,5 +1,4 @@
 import functools
-import collections
 
 import caproto as ca
 import trio
@@ -107,8 +106,6 @@ class VirtualCircuit(_VirtualCircuit):
                     ...
                 except LoopExit:
                     ...
-                except Exception:
-                    print('exiting')
 
     async def subscription_queue_loop(self, task_status):
         task_status.started()

--- a/caproto/trio/util.py
+++ b/caproto/trio/util.py
@@ -1,0 +1,15 @@
+import collections
+import trio
+
+
+TrioMemoryChannelPair = collections.namedtuple('TrioMemoryChannelPair',
+                                               'send receive')
+
+
+def open_memory_channel(max_items):
+    '''Wrapper around trio.open_memory_channel, which patches the send channel
+    for queue-like compatibility'''
+    send, recv = trio.open_memory_channel(max_items)
+    # monkey-patch here for compatibility with a regular queue:
+    send.put = send.send
+    return TrioMemoryChannelPair(send, recv)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ classifiers = [
 
 extras_require = {
     'standard': ['netifaces', 'numpy'],
-    'async': ['asks', 'curio', 'trio'],
+    'async': ['asks', 'curio', 'trio>=0.9.0'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ pytest-rerunfailures==4.1
 asv
 asks
 ophyd
-trio==0.9.0
+trio


### PR DESCRIPTION
This PR looks more drastic than it is. It effectively breaks up the "common" server loops into 2 methods - splitting queue access and parse/respond:
1. `*_loop()` Reference loop implementation, functioning just like current master's loops - grabbing from a queue and calling `*_iteration()` (2)
2. `*_iteration()` "Single iteration" - the portion which takes a single command and does something with it

I think I prefer this compared to the current implementation regardless of the trio memory channel refactor.

Addresses #357 