### PR TITLE
FIX: use by default minimum MTU likely to be seen in the wild

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E402
+ignore = E402,W504
 exclude = .git,__pycache__,doc/source/conf.py,build,dist,versioneer.py,caproto/_headers.py,caproto/tests/test_pyepics_compat.py,caproto/_version.py
 max-line-length = 115

--- a/caproto/_constants.py
+++ b/caproto/_constants.py
@@ -17,11 +17,9 @@ MAX_RECORD_LENGTH = 59  # from 3.14 on
 MAX_UDP_RECV = 0xffff - 16
 
 STALE_SEARCH_EXPIRATION = 10.0
-# In theory (0xffff - 16) is allowed but in practice this can be too high
-# without special system configuration. For more info on this and to see where
-# this number comes from refer to
-# https://stackoverflow.com/a/35335138/1221924
-SEARCH_MAX_DATAGRAM_BYTES = 9216
+
+# Max of ethernet and 802.{2,3} MTU 1500 - 20(IP header) - 8(UDP header)
+SEARCH_MAX_DATAGRAM_BYTES = 1472
 
 # Servers send beacons at some maximum interval. ("Maximum delay between
 # beacons will be limited by server specified parameter, but is commonly 15

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -451,7 +451,7 @@ class ChannelData:
         try:
             value = self.preprocess_value(value)
             modified_value = await self.verify_value(value)
-        except Exception as ex:
+        except Exception:
             # TODO: should allow exception to optionally pass alarm
             # status/severity through exception instance
             await self.alarm.write(status=AlarmStatus.WRITE,

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -259,7 +259,7 @@ class Context(_Context):
                 t.cancel()
             await asyncio.wait(all_tasks)
             return
-        except Exception as ex:
+        except Exception:
             self.log.exception('Server error. Will shut down')
             raise
         finally:

--- a/caproto/ioc_examples/caproto_to_ophyd.py
+++ b/caproto/ioc_examples/caproto_to_ophyd.py
@@ -36,8 +36,8 @@ class Group(PVGroup):
 
     @pvfunction(default=0)
     async def get_random(self,
-                         low: int=100,
-                         high: int=1000) -> int:
+                         low: int = 100,
+                         high: int = 1000) -> int:
         'A configurable random number'
         return random.randint(low, high)
 
@@ -59,7 +59,7 @@ class get_randomDevice(ophyd.Device):
     process = Cpt(EpicsSignal, 'Process',
                   doc="Parameter <class 'int'> Process")
 
-    def call(self, low: int=100, high: int=1000):
+    def call(self, low: int = 100, high: int = 1000):
         'A configurable random number'
         self.low.put(low, wait=True)
         self.high.put(high, wait=True)

--- a/caproto/ioc_examples/rpc_function.py
+++ b/caproto/ioc_examples/rpc_function.py
@@ -16,8 +16,8 @@ class MyPVGroup(PVGroup):
 
     @pvfunction(default=[0])
     async def get_random(self,
-                         low: int=100,
-                         high: int=1000) -> int:
+                         low: int = 100,
+                         high: int = 1000) -> int:
         'A configurable random number'
         return random.randint(low, high)
 

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -124,7 +124,7 @@ class VirtualCircuit:
         """
         try:
             bytes_received = await self.client.recv(4096)
-        except (ConnectionResetError, ConnectionAbortedError) as ex:
+        except (ConnectionResetError, ConnectionAbortedError):
             bytes_received = []
 
         commands, _ = self.circuit.recv(bytes_received)
@@ -198,9 +198,8 @@ class VirtualCircuit:
                                    "unrecoverable way.", exc_info=ex)
                     # TODO: Kill the circuit.
                     break
-            except Exception as ex:
-                self.log.error('Circuit command queue evaluation failed',
-                               exc_info=ex)
+            except Exception:
+                self.log.exception('Circuit command queue evaluation failed')
                 continue
 
             try:
@@ -219,8 +218,8 @@ class VirtualCircuit:
                                        'disconnection: %s', command)
                     break
 
-                self.log.error('Server failed to process command: %s',
-                               command, exc_info=ex)
+                self.log.exception('Server failed to process command: %s',
+                                   command)
 
                 if hasattr(command, 'sid'):
                     cid = self.circuit.channels_sid[command.sid].cid

--- a/caproto/server/conversion.py
+++ b/caproto/server/conversion.py
@@ -77,7 +77,7 @@ def ophyd_component_to_caproto(attr, component, *, depth=0, dev=None):
             # NELM reflects the actual maximum length of the value, as opposed
             # to the current length
             max_length = sig._read_pv.nelm
-        except Exception as ex:
+        except Exception:
             max_length = 1
 
         if array_checker(value):

--- a/caproto/server/server.py
+++ b/caproto/server/server.py
@@ -275,7 +275,7 @@ class PVSpec(namedtuple('PVSpec',
             sig = inspect.signature(get)
             try:
                 sig.bind('group', 'instance')
-            except Exception as ex:
+            except Exception:
                 raise RuntimeError('Invalid signature for getter {}: {}'
                                    ''.format(get, sig))
 
@@ -285,7 +285,7 @@ class PVSpec(namedtuple('PVSpec',
             sig = inspect.signature(put)
             try:
                 sig.bind('group', 'instance', 'value')
-            except Exception as ex:
+            except Exception:
                 raise RuntimeError('Invalid signature for putter {}: {}'
                                    ''.format(put, sig))
 
@@ -295,7 +295,7 @@ class PVSpec(namedtuple('PVSpec',
             sig = inspect.signature(startup)
             try:
                 sig.bind('group', 'instance', 'async_library')
-            except Exception as ex:
+            except Exception:
                 raise RuntimeError('Invalid signature for startup {}: {}'
                                    ''.format(startup, sig))
 
@@ -305,7 +305,7 @@ class PVSpec(namedtuple('PVSpec',
             sig = inspect.signature(shutdown)
             try:
                 sig.bind('group', 'instance', 'async_library')
-            except Exception as ex:
+            except Exception:
                 raise RuntimeError('Invalid signature for shutdown {}: {}'
                                    ''.format(shutdown, sig))
 
@@ -526,7 +526,7 @@ class pvproperty:
             async def call_scan_function(group, prop, async_lib):
                 try:
                     await scan_function(group, prop, async_lib)
-                except Exception as ex:
+                except Exception:
                     prop.log.exception('Scan exception')
                     await prop.alarm.write(status=AlarmStatus.SCAN,
                                            severity=failure_severity,

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -47,7 +47,7 @@ def check_clients(clients, skip=None):
                                  socket.IPPROTO_UDP)
         try:
             sock.bind(addr)
-        except Exception as ex:
+        except Exception:
             # in use, still taken by client
             ...
         else:
@@ -97,7 +97,7 @@ def _run_repeater(server_sock, bind_addr):
         try:
             commands = broadcaster.recv(msg, addr)
             broadcaster.process_commands(commands)
-        except Exception as ex:
+        except Exception:
             logger.exception('Failed to process incoming datagram')
             continue
 
@@ -150,7 +150,7 @@ def _run_repeater(server_sock, bind_addr):
                 try:
                     server_sock.sendto(bytes_to_broadcast, (other_host,
                                                             other_port))
-                except Exception as ex:
+                except Exception:
                     to_remove.append((other_host, other_port))
 
         if to_remove:

--- a/caproto/tests/_asv_shim.py
+++ b/caproto/tests/_asv_shim.py
@@ -237,7 +237,7 @@ def pytest_benchmark_update_json(config, benchmarks, output_json):
 
         logger.info('Saving asv-style JSON to %s', asv_path)
         save_asv_results(asv_path, **results)
-    except Exception as ex:
+    except Exception:
         logger.exception('Failed to update pytest benchmark json; '
                          'asv results not saved')
 

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -556,7 +556,7 @@ def test_multithreaded_many_subscribe(ioc, context, thread_count,
     print(f'initial value is: {initial_value!r}')
     try:
         results = _multithreaded_exec(_test, thread_count + 1)
-    except threading.BrokenBarrierError as ex:
+    except threading.BrokenBarrierError:
         if init_barrier.broken:
             print(f'Init barrier broken!')
         if sub_ended_barrier.broken:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -336,7 +336,7 @@ class SharedBroadcaster:
         try:
             # Always attempt registration on initialization, but allow failures
             self._register()
-        except Exception as ex:
+        except Exception:
             self.log.exception('Broadcaster registration failed on init')
 
     def _should_attempt_registration(self):
@@ -1244,7 +1244,7 @@ class VirtualCircuitManager:
         sock, self.socket = self.socket, None
         try:
             sock.shutdown(socket.SHUT_WR)
-        except OSError as ex:
+        except OSError:
             pass
         self.log.debug('Circuit manager disconnected by user')
 

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -224,8 +224,8 @@ class PV:
         )
 
         if self._caproto_pv.connected:
-            # connection state callback was already called
-            self._connection_established(self._caproto_pv)
+            # connection state callback was already called but we didn't see it
+            self._connection_state_changed(self._caproto_pv, 'connected')
 
     @property
     def connected(self):

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -314,7 +314,7 @@ class PV:
             try:
                 if connected:
                     self._connection_established(caproto_pv)
-            except Exception as ex:
+            except Exception:
                 raise
             finally:
                 self._connect_event.set()

--- a/generate_headers.py
+++ b/generate_headers.py
@@ -17,7 +17,7 @@ Param = namedtuple('Param', ['standard_name', 'field', 'value', 'description'])
 Command = namedtuple('Command', ['name', 'description',
                                  'input_params', 'struct_args'])
 
-COMMAND_NAME_PATTERN = re.compile("Command identifier for ([A-Z_]+)\.?")
+COMMAND_NAME_PATTERN = re.compile("Command identifier for ([A-Z_]+).?")
 
 
 def validate(params):


### PR DESCRIPTION
TODO: consider determining MTU per interface dynamically in the future.
There may not be portable solutions for this.

Linux: https://gist.github.com/nzjrs/8934855

(Seen on ophyd areadetector testing on OSX - part of an upcoming PR)

Edit: 
(1) a bit of pork in 232a169, pyepics compat in threading client was calling the incorrect connection state changed method, meaning that `epics.PV` connection callbacks were never run.

(2) new flake8 is much more strict