### PR TITLE
ENH: More debug prints in threading client.

### DIFF
--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -25,6 +25,7 @@ from ._commands import (AccessRightsResponse, CreateChFailResponse,
 from ._state import (ChannelState, CircuitState, get_exception)
 from ._utils import (CLIENT, SERVER, NEED_DATA, DISCONNECTED, CaprotoKeyError,
                      CaprotoValueError, CaprotoRuntimeError, CaprotoError,
+                     CaprotoTypeError,
                      parse_channel_filter, parse_record_field,
                      ChannelFilter)
 from ._dbr import (ChannelType, SubscriptionType, field_types, native_type)
@@ -952,8 +953,8 @@ def extract_address(search_response):
     Extract the (host, port) from a SearchResponse.
     """
     if type(search_response) is not SearchResponse:
-        raise TypeError("expected SearchResponse, not {!r}"
-                        "".format(type(search_response).__name__))
+        raise CaprotoTypeError("expected SearchResponse, not {!r}"
+                               "".format(type(search_response).__name__))
     if search_response.header.parameter1 == 0xffffffff:
         # The CA spec tells us that this sentinel value means we
         # should fall back to using the address of the sender of

--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -437,7 +437,7 @@ class ChannelData:
             await self.alarm.write(must_acknowledge_transient=metadata.value)
             return
         elif data_type in (ChannelType.STSACK_STRING, ChannelType.CLASS_NAME):
-            raise ValueError('Bad request')
+            raise CaprotoValueError('Bad request')
 
         timestamp = time.time()
         native_from = native_type(data_type)
@@ -784,7 +784,7 @@ class ChannelByte(ChannelNumeric):
     def __init__(self, *, string_encoding=None, strip_null_terminator=True,
                  **kwargs):
         if string_encoding is not None:
-            raise ValueError('ChannelByte cannot have a string encoding')
+            raise CaprotoValueError('ChannelByte cannot have a string encoding')
 
         self.strip_null_terminator = strip_null_terminator
         super().__init__(string_encoding=None, **kwargs)
@@ -801,7 +801,7 @@ class ChannelByte(ChannelNumeric):
                 value = b''.join(map(bytes, ([v] for v in value)))
 
         if isinstance(value, str):
-            raise ValueError('ChannelByte does not accept decoded strings')
+            raise CaprotoValueError('ChannelByte does not accept decoded strings')
 
         if self.strip_null_terminator:
             value = value.rstrip(b'\x00')

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -52,6 +52,7 @@ __all__ = (  # noqa F822
     'ProtocolError',
     'LocalProtocolError',
     'RemoteProtocolError',
+    'CaprotoTimeoutError',
     'CaprotoKeyError',
     'CaprotoNotImplementedError',
     'CaprotoValueError',
@@ -149,6 +150,10 @@ class RemoteProtocolError(ProtocolError):
     """
     Your remote peer tried to do something that caproto thinks is illegal.
     """
+    ...
+
+
+class CaprotoTimeoutError(TimeoutError, CaprotoError):
     ...
 
 

--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -54,6 +54,7 @@ __all__ = (  # noqa F822
     'RemoteProtocolError',
     'CaprotoTimeoutError',
     'CaprotoKeyError',
+    'CaprotoAttributeError',
     'CaprotoNotImplementedError',
     'CaprotoValueError',
     'CaprotoTypeError',
@@ -154,6 +155,10 @@ class RemoteProtocolError(ProtocolError):
 
 
 class CaprotoTimeoutError(TimeoutError, CaprotoError):
+    ...
+
+
+class CaprotoAttributeError(AttributeError, CaprotoError):
     ...
 
 
@@ -312,7 +317,7 @@ def get_netifaces_addresses():
     Yields (address, broadcast_address)
     '''
     if netifaces is None:
-        raise RuntimeError('netifaces unavailable')
+        raise CaprotoRuntimeError('netifaces unavailable')
 
     for iface in netifaces.interfaces():
         interface = netifaces.ifaddresses(iface)
@@ -402,7 +407,7 @@ def bcast_socket(socket_module=socket):
 def buffer_list_slice(*buffers, offset):
     'Helper function for slicing a list of buffers'
     if offset < 0:
-        raise ValueError('Negative offset')
+        raise CaprotoValueError('Negative offset')
 
     buffers = tuple(memoryview(b).cast('b') for b in buffers)
 
@@ -415,8 +420,8 @@ def buffer_list_slice(*buffers, offset):
 
         start = end
 
-    raise ValueError('Offset beyond end of buffers (total length={} offset={})'
-                     ''.format(end, offset))
+    raise CaprotoValueError('Offset beyond end of buffers '
+                            '(total length={} offset={})'.format(end, offset))
 
 
 def incremental_buffer_list_slice(*buffers):

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -7,7 +7,7 @@ import time
 import weakref
 import caproto as ca
 from caproto import (apply_arr_filter, get_environment_variables,
-                     RemoteProtocolError)
+                     RemoteProtocolError, CaprotoKeyError, CaprotoRuntimeError)
 from .._dbr import SubscriptionType
 
 
@@ -638,14 +638,14 @@ class Context:
             try:
                 inst = self.pvdb[rec]
             except KeyError:
-                raise KeyError(f'Neither record nor field exists: '
-                               f'{rec_field}')
+                raise CaprotoKeyError(f'Neither record nor field exists: '
+                                      f'{rec_field}')
 
             try:
                 inst = inst.get_field(field)
             except (AttributeError, KeyError):
-                raise KeyError(f'Neither record nor field exists: '
-                               f'{rec_field}')
+                raise CaprotoKeyError(f'Neither record nor field exists: '
+                                      f'{rec_field}')
 
             # Cache record.FIELD for later usage
             self.pvdb[rec_field] = inst
@@ -868,7 +868,7 @@ class Context:
             else:
                 break
         else:
-            raise RuntimeError('No available ports and/or bind failed') from stashed_ex
+            raise CaprotoRuntimeError('No available ports and/or bind failed') from stashed_ex
         return port, tcp_sockets
 
     async def tcp_handler(self, client, addr):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1455,7 +1455,7 @@ class PV:
         deadline = time.monotonic() + timeout if timeout is not None else None
         ioid_info['deadline'] = deadline
         self.circuit_manager.send(command)
-        self.log.debug(f"{self.name!r}: {command}")
+        self.log.debug("%r: %r", self.name, command)
         if not wait:
             return
 
@@ -1475,7 +1475,7 @@ class PV:
                 f"{self.name!r} within {timeout}-second timeout."
             )
 
-        self.log.debug(f"{self.name!r}: {ioid_info['response']}")
+        self.log.debug("%r: %r", self.name, ioid_info['response'])
         return ioid_info['response']
 
     @ensure_connected
@@ -1543,7 +1543,7 @@ class PV:
         ioid_info['deadline'] = deadline
         # do not need to lock this, locking happens in circuit command
         self.circuit_manager.send(command)
-        self.log.debug(f"{self.name!r}: {command}")
+        self.log.debug("%r: %r", self.name, command)
         if not wait:
             return
 
@@ -1563,7 +1563,7 @@ class PV:
                 f"{self.name!r} within {timeout}-second timeout. The ioid of "
                 f"the expected response is {ioid}."
             )
-        self.log.debug(f"{self.name!r}: {ioid_info['response']}")
+        self.log.debug("%r: %r", self.name, ioid_info['response'])
         return ioid_info['response']
 
     def subscribe(self, data_type=None, data_count=None,
@@ -1786,7 +1786,7 @@ class Subscription(CallbackHandler):
         # the CA servers from processing. (-> ThreadPool, etc.)
 
         super().process(command)
-        self.log.debug(f"{self.pv.name!r}: {command}")
+        self.log.debug("%r: %r", self.pv.name, command)
         self.most_recent_response = command
 
     def add_callback(self, func):

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -10,7 +10,7 @@ from collections import Iterable
 import caproto as ca
 from .client import (Context, SharedBroadcaster, AUTOMONITOR_MAXLENGTH,
                      STR_ENC)
-from caproto import AccessRights, field_types, ChannelType
+from caproto import AccessRights, field_types, ChannelType, CaprotoTimeoutError
 
 
 __all__ = ('PV', 'get_pv', 'caget', 'caput')
@@ -259,9 +259,9 @@ class PV:
         ok = ok and self.connected
 
         if not ok:
-            raise TimeoutError(f'{self.pvname} failed to connect within '
-                               f'{timeout} seconds '
-                               f'(caproto={self._caproto_pv})')
+            raise CaprotoTimeoutError(f'{self.pvname} failed to connect within '
+                                      f'{timeout} seconds '
+                                      f'(caproto={self._caproto_pv})')
 
         return True
 

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -10,7 +10,9 @@ from collections import Iterable
 import caproto as ca
 from .client import (Context, SharedBroadcaster, AUTOMONITOR_MAXLENGTH,
                      STR_ENC)
-from caproto import AccessRights, field_types, ChannelType, CaprotoTimeoutError
+from caproto import (AccessRights, field_types, ChannelType,
+                     CaprotoTimeoutError, CaprotoValueError,
+                     CaprotoRuntimeError, CaprotoNotImplementedError)
 
 
 __all__ = ('PV', 'get_pv', 'caget', 'caput')
@@ -107,7 +109,7 @@ def _pyepics_get_value(value, string_value, full_type, native_count, *,
         return string_value
     if as_string and full_type in ca.enum_types:
         if enum_strings is None:
-            raise ValueError('Enum strings unset')
+            raise CaprotoValueError('Enum strings unset')
         ret = []
         for r in value:
             try:
@@ -173,7 +175,7 @@ class PV:
         if context is None:
             context = self._default_context
         if context is None:
-            raise RuntimeError("must have a valid context")
+            raise CaprotoRuntimeError("must have a valid context")
         self._context = context
         self.pvname = pvname.strip()
         self.form = form.lower()
@@ -234,7 +236,7 @@ class PV:
 
     def force_connect(self, pvname=None, chid=None, conn=True, **kws):
         # not quite sure what this is for in pyepics
-        raise NotImplementedError
+        raise CaprotoNotImplementedError
 
     def wait_for_connection(self, timeout=None):
         """wait for a connection that started with connect() to finish
@@ -433,7 +435,7 @@ class PV:
                 try:
                     value = self.enum_strs.index(value)
                 except ValueError:
-                    raise ValueError('{} is not in Enum ({}'.format(
+                    raise CaprotoValueError('{} is not in Enum ({}'.format(
                         value, self.enum_strs))
 
         if isinstance(value, str):
@@ -569,9 +571,9 @@ class PV:
         has a unique index (small integer) that is returned by
         add_callback.  This index is needed to remove a callback."""
         if not callable(callback):
-            raise ValueError()
+            raise CaprotoValueError()
         if index is not None:
-            raise ValueError("why do this")
+            raise CaprotoValueError("why do this")
         index = next(self._cb_count)
         self.callbacks[index] = (callback, kw)
 
@@ -984,7 +986,7 @@ def caput_many(pvlist, values, wait=False, connection_timeout=None,
     was exceeded.
     """
     if len(pvlist) != len(values):
-        raise ValueError("List of PV names must be equal to list of values.")
+        raise CaprotoValueError("List of PV names must be equal to list of values.")
 
     # context = PV._default_context
     # TODO: context.get_pvs(...)


### PR DESCRIPTION
The current DEBUG logs do not include PV names except at channel
creation time. This adds DEBUG logs to channel-level logging that
include the PV name, read request/response, write request/response, and
event response. It omits event request because that is managed
asynchrously by the circuit and is typically of lower operational
interest.

![image](https://user-images.githubusercontent.com/2279598/47538097-9f5af600-d897-11e8-9f5b-8aef90984c49.png)
