### PR TITLE
ENH: Show better error msg with addr if sendto fails.

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -60,6 +60,7 @@ __all__ = (  # noqa F822
     'CaprotoTypeError',
     'CaprotoConversionError',
     'CaprotoRuntimeError',
+    'CaprotoNetworkError',
     'ErrorResponseReceived',
     'SendAllRetry',
     'RecordModifiers',
@@ -191,6 +192,10 @@ class CaprotoTypeError(TypeError, CaprotoError):
 
 
 class CaprotoRuntimeError(RuntimeError, CaprotoError):
+    ...
+
+
+class CaprotoNetworkError(OSError, CaprotoError):
     ...
 
 

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -200,7 +200,8 @@ class Context(_Context):
                 try:
                     self.transport.sendto(bytes_to_send, addr_port)
                 except OSError as exc:
-                    raise ca.CaprotoNetworkError(f"Failed to send to {addr_port}") from exc
+                    host, port = addr_port
+                    raise ca.CaprotoNetworkError(f"Failed to send to {host}:{port}") from exc
 
             def close(self):
                 return self.transport.close()
@@ -215,8 +216,9 @@ class Context(_Context):
                 try:
                     self.transport.sendto(bytes_to_send, self.address)
                 except OSError as exc:
+                    host, port = self.address
                     raise ca.CaprotoNetworkError(
-                        f"Failed to send to {self.address}") from exc
+                        f"Failed to send to {host}:{port}") from exc
 
             def close(self):
                 return self.transport.close()

--- a/caproto/asyncio/server.py
+++ b/caproto/asyncio/server.py
@@ -197,7 +197,10 @@ class Context(_Context):
                 self.transport = transport
 
             async def sendto(self, bytes_to_send, addr_port):
-                self.transport.sendto(bytes_to_send, addr_port)
+                try:
+                    self.transport.sendto(bytes_to_send, addr_port)
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(f"Failed to send to {addr_port}") from exc
 
             def close(self):
                 return self.transport.close()
@@ -209,7 +212,11 @@ class Context(_Context):
                 self.address = address
 
             async def send(self, bytes_to_send):
-                self.transport.sendto(bytes_to_send, self.address)
+                try:
+                    self.transport.sendto(bytes_to_send, self.address)
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(
+                        f"Failed to send to {self.address}") from exc
 
             def close(self):
                 return self.transport.close()

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -249,10 +249,18 @@ class SharedBroadcaster:
         for host in ca.get_address_list():
             if ':' in host:
                 host, _, specified_port = host.partition(':')
-                await self.udp_sock.sendto(bytes_to_send,
-                                           (host, int(specified_port)))
+                try:
+                    await self.udp_sock.sendto(bytes_to_send,
+                                               (host, int(specified_port)))
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(
+                        f"Failed to send to {(host, specified_port)}") from exc
             else:
-                await self.udp_sock.sendto(bytes_to_send, (host, port))
+                try:
+                    await self.udp_sock.sendto(bytes_to_send, (host, port))
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(
+                        f"Failed to send to {(host, port)}") from exc
 
     async def register(self):
         "Register this client with the CA Repeater."

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -247,20 +247,16 @@ class SharedBroadcaster:
         """
         bytes_to_send = self.broadcaster.send(*commands)
         for host in ca.get_address_list():
-            if ':' in host:
-                host, _, specified_port = host.partition(':')
-                try:
-                    await self.udp_sock.sendto(bytes_to_send,
-                                               (host, int(specified_port)))
-                except OSError as exc:
-                    raise ca.CaprotoNetworkError(
-                        f"Failed to send to {(host, specified_port)}") from exc
-            else:
-                try:
+            try:
+                if ':' in host:
+                    host, _, port_as_str = host.partition(':')
+                    port = int(port_as_str)
                     await self.udp_sock.sendto(bytes_to_send, (host, port))
-                except OSError as exc:
-                    raise ca.CaprotoNetworkError(
-                        f"Failed to send to {(host, port)}") from exc
+                else:
+                    await self.udp_sock.sendto(bytes_to_send, (host, port))
+            except OSError as exc:
+                raise ca.CaprotoNetworkError(
+                    f"Failed to send to {host}:{port}") from exc
 
     async def register(self):
         "Register this client with the CA Repeater."

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -709,7 +709,8 @@ class Context:
                 try:
                     await udp_sock.sendto(bytes_to_send, addr)
                 except OSError as exc:
-                    raise CaprotoNetworkError(f"Failed to send to {addr}") from exc
+                    host, port = addr
+                    raise CaprotoNetworkError(f"Failed to send to {host}:{port}") from exc
 
     async def subscription_queue_loop(self):
         while True:

--- a/caproto/server/common.py
+++ b/caproto/server/common.py
@@ -6,7 +6,8 @@ import time
 import weakref
 import caproto as ca
 from caproto import (apply_arr_filter, get_environment_variables,
-                     RemoteProtocolError, CaprotoKeyError, CaprotoRuntimeError)
+                     RemoteProtocolError, CaprotoKeyError, CaprotoRuntimeError,
+                     CaprotoNetworkError)
 from .._dbr import SubscriptionType
 
 
@@ -705,7 +706,10 @@ class Context:
                 bytes_to_send = self.broadcaster.send(*search_replies)
 
             for udp_sock in self.udp_socks.values():
-                await udp_sock.sendto(bytes_to_send, addr)
+                try:
+                    await udp_sock.sendto(bytes_to_send, addr)
+                except OSError as exc:
+                    raise CaprotoNetworkError(f"Failed to send to {addr}") from exc
 
     async def subscription_queue_loop(self):
         while True:

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -57,7 +57,7 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
         try:
             udp_sock.sendto(bytes_to_send, (host, repeater_port))
         except OSError as exc:
-            raise ca.CaprotoNetworkError(f"Failed to send to {(host, repeater_port)}") from exc
+            raise ca.CaprotoNetworkError(f"Failed to send to {host}:{repeater_port}") from exc
 
     logger.debug("Searching for '%s'....", pv_name)
     bytes_to_send = b.send(
@@ -74,7 +74,8 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
             try:
                 udp_sock.sendto(bytes_to_send, dest)
             except OSError as exc:
-                raise ca.CaprotoNetworkError(f"Failed to send to {dest}") from exc
+                host, port = dest
+                raise ca.CaprotoNetworkError(f"Failed to send to {host}:{port}") from exc
             logger.debug('Search request sent to %r.', dest)
 
     def check_timeout():

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -54,7 +54,10 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
 
     repeater_port = os.environ.get('EPICS_CA_REPEATER_PORT', 5065)
     for host in ca.get_address_list():
-        udp_sock.sendto(bytes_to_send, (host, repeater_port))
+        try:
+            udp_sock.sendto(bytes_to_send, (host, repeater_port))
+        except OSError as exc:
+            raise ca.CaprotoNetworkError(f"Failed to send to {(host, repeater_port)}") from exc
 
     logger.debug("Searching for '%s'....", pv_name)
     bytes_to_send = b.send(
@@ -68,7 +71,10 @@ def search(pv_name, udp_sock, timeout, *, max_retries=2):
                 dest = (host, int(specified_port))
             else:
                 dest = (host, CA_SERVER_PORT)
-            udp_sock.sendto(bytes_to_send, dest)
+            try:
+                udp_sock.sendto(bytes_to_send, dest)
+            except OSError as exc:
+                raise ca.CaprotoNetworkError(f"Failed to send to {dest}") from exc
             logger.debug('Search request sent to %r.', dest)
 
     def check_timeout():

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -135,7 +135,11 @@ def _run_repeater(server_sock, bind_addr):
                 confirmation_bytes = broadcaster.send(
                     caproto.RepeaterConfirmResponse(host))
 
-                server_sock.sendto(confirmation_bytes, (host, port))
+                try:
+                    server_sock.sendto(confirmation_bytes, (host, port))
+                except OSError as exc:
+                    raise caproto.CaprotoNetworkError(
+                        f"Failed to send to {(host, port)}") from exc
 
                 remove_clients = list(check_clients(clients, skip=port))
                 _update_all(clients, servers, remove_clients=remove_clients)

--- a/caproto/sync/repeater.py
+++ b/caproto/sync/repeater.py
@@ -139,7 +139,7 @@ def _run_repeater(server_sock, bind_addr):
                     server_sock.sendto(confirmation_bytes, (host, port))
                 except OSError as exc:
                     raise caproto.CaprotoNetworkError(
-                        f"Failed to send to {(host, port)}") from exc
+                        f"Failed to send to {host}:{port}") from exc
 
                 remove_clients = list(check_clients(clients, skip=port))
                 _update_all(clients, servers, remove_clients=remove_clients)

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -35,7 +35,7 @@ from .._constants import (MAX_ID, STALE_SEARCH_EXPIRATION,
 from .._utils import (batch_requests, CaprotoError, ThreadsafeCounter,
                       socket_bytes_available, CaprotoTimeoutError,
                       CaprotoTypeError, CaprotoRuntimeError, CaprotoValueError,
-                      CaprotoKeyError)
+                      CaprotoKeyError, CaprotoNetworkError)
 
 
 print = partial(print, flush=True)
@@ -433,8 +433,8 @@ class SharedBroadcaster:
                 else:
                     self.udp_sock.sendto(bytes_to_send, (host, port))
             except OSError as ex:
-                raise OSError(f'{ex} while sending {len(bytes_to_send)} '
-                              f'bytes to {host}:{port}') from ex
+                raise CaprotoNetworkError(
+                    f'{ex} while sending {len(bytes_to_send)} bytes to {host}:{port}') from ex
 
     def get_cached_search_result(self, name, *,
                                  threshold=STALE_SEARCH_EXPIRATION):

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -280,20 +280,16 @@ class SharedBroadcaster:
         """
         bytes_to_send = self.broadcaster.send(*commands)
         for host in ca.get_address_list():
-            if ':' in host:
-                host, _, specified_port = host.partition(':')
-                try:
-                    await self.udp_sock.sendto(bytes_to_send,
-                                               (host, int(specified_port)))
-                except OSError as exc:
-                    raise ca.CaprotoNetworkError(
-                        f"Failed to send to {(host, specified_port)}") from exc
-            else:
-                try:
+            try:
+                if ':' in host:
+                    host, _, port_as_str = host.partition(':')
+                    port = int(port_as_str)
                     await self.udp_sock.sendto(bytes_to_send, (host, port))
-                except OSError as exc:
-                    raise ca.CaprotoNetworkError(
-                        f"Failed to send to {(host, port)}") from exc
+                else:
+                    await self.udp_sock.sendto(bytes_to_send, (host, port))
+            except OSError as exc:
+                raise ca.CaprotoNetworkError(
+                    f"Failed to send to {host}:{port}") from exc
 
     async def disconnect(self):
         'Disconnect the broadcaster and stop listening'

--- a/caproto/trio/client.py
+++ b/caproto/trio/client.py
@@ -282,10 +282,18 @@ class SharedBroadcaster:
         for host in ca.get_address_list():
             if ':' in host:
                 host, _, specified_port = host.partition(':')
-                await self.udp_sock.sendto(bytes_to_send,
-                                           (host, int(specified_port)))
+                try:
+                    await self.udp_sock.sendto(bytes_to_send,
+                                               (host, int(specified_port)))
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(
+                        f"Failed to send to {(host, specified_port)}") from exc
             else:
-                await self.udp_sock.sendto(bytes_to_send, (host, port))
+                try:
+                    await self.udp_sock.sendto(bytes_to_send, (host, port))
+                except OSError as exc:
+                    raise ca.CaprotoNetworkError(
+                        f"Failed to send to {(host, port)}") from exc
 
     async def disconnect(self):
         'Disconnect the broadcaster and stop listening'


### PR DESCRIPTION
Should improve this kind of scenario by chaining the OSError with a
CaprotoNetworkError that includes the address we attempted to connect
to.

```
$ caproto-get simple:A -vvv
[D 11:47:43.096 repeater:213] Another repeater is already running; will not spawn one.
[D 11:47:43.097 client:52] Registering with the Channel Access repeater.
[D 11:47:43.097 _broadcaster:72] Serializing 1 commands into one datagram
[D 11:47:43.097 _broadcaster:75] 1 of 1 RepeaterRegisterRequest(client_address='0.0.0.0')
Traceback (most recent call last):
  File "/Users/mrakitin/anaconda3/envs/bluesky/bin/caproto-get", line 11, in <module>
    load_entry_point('caproto', 'console_scripts', 'caproto-get')()
  File "/Users/mrakitin/anaconda3/envs/bluesky/lib/python3.6/site-packages/caproto/commandline/get.py", line 102, in main
    repeater=not args.no_repeater)
  File "/Users/mrakitin/anaconda3/envs/bluesky/lib/python3.6/site-packages/caproto/sync/client.py", line 234, in read
    chan = make_channel(pv_name, udp_sock, priority, timeout)
  File "/Users/mrakitin/anaconda3/envs/bluesky/lib/python3.6/site-packages/caproto/sync/client.py", line 124, in make_channel
    address = search(pv_name, udp_sock, timeout)
  File "/Users/mrakitin/anaconda3/envs/bluesky/lib/python3.6/site-packages/caproto/sync/client.py", line 57, in search
    udp_sock.sendto(bytes_to_send, (host, repeater_port))
OSError: [Errno 49] Can't assign requested address
```

with <3 for @mrakitin