### PR TITLE
FIX: connected property should not acquire lock

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1543,11 +1543,10 @@ class PV:
 
     @property
     def connected(self):
-        with self.component_lock:
-            channel = self.channel
-            if channel is None:
-                return False
-            return channel.states[ca.CLIENT] is ca.CONNECTED
+        channel = self.channel
+        if channel is None:
+            return False
+        return channel.states[ca.CLIENT] is ca.CONNECTED
 
     def wait_for_search(self, *, timeout=2):
         """


### PR DESCRIPTION
This appears to be causing deadlock while using connection callbacks in ophyd.