### PR TITLE
**DO_NOT_MERGE** thread lock debugging / ophyd stage

### DIFF
--- a/caproto/_broadcaster.py
+++ b/caproto/_broadcaster.py
@@ -95,8 +95,8 @@ class Broadcaster:
         -------
         commands : list
         """
-        self.log.debug("Received datagram from %r with %d bytes.",
-                       address, len(byteslike))
+        self.log.debug("Received datagram from %s:%d with %d bytes.",
+                       *address, len(byteslike))
         try:
             commands = read_datagram(byteslike, address, self.their_role)
         except Exception as ex:

--- a/caproto/_circuit.py
+++ b/caproto/_circuit.py
@@ -181,13 +181,12 @@ class VirtualCircuit:
              command,
              num_bytes_needed) = read_from_bytestream(self._data,
                                                       self.their_role)
-            len_data = len(self._data)  # just for logging
             if command is not NEED_DATA:
                 self.log.debug("%d bytes -> %r", len(command), command)
                 commands.append(command)
             else:
-                self.log.debug("%d bytes are cached. Need more bytes to parse "
-                               "next command.", len_data)
+                # Less than a full command's worth of bytes are cached. Wait
+                # for more bytes to come in before continuing parsing.
                 break
         return commands, num_bytes_needed
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1217,6 +1217,8 @@ class VirtualCircuitManager:
         # Connect.
         if self.circuit.states[ca.SERVER] is ca.IDLE:
             self.socket = socket.create_connection(self.circuit.address)
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.selector.add_socket(self.socket, self)
             self.send(ca.VersionRequest(self.circuit.priority,
                                         ca.DEFAULT_PROTOCOL_VERSION),

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1320,14 +1320,9 @@ class VirtualCircuitManager:
             if deadline is not None and time.monotonic() > deadline:
                 self.log.warn(f"ignoring late response with "
                               f"ioid={command.ioid} because it arrived "
-                              f"{time.monotonic() - ioid_info['deadline']} "
-                              f"seconds after the deadline specified by the "
-                              f"timeout."
-                              )
-            else:
-                callback = ioid_info.get('callback')
-                if callback is not None:
-                    self.user_callback_executor.submit(callback, command)
+                              f"{time.monotonic() - deadline} seconds after "
+                              f"the deadline specified by the timeout.")
+                return
 
             event = ioid_info.get('event')
             if event is not None:
@@ -1337,6 +1332,9 @@ class VirtualCircuitManager:
                 # are waiting on.
                 ioid_info['response'] = command
                 event.set()
+            callback = ioid_info.get('callback')
+            if callback is not None:
+                self.user_callback_executor.submit(callback, command)
 
         elif isinstance(command, ca.EventAddResponse):
             try:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1336,8 +1336,7 @@ class VirtualCircuitManager:
                 # provide the response to them and then set the Event that they
                 # are waiting on.
                 ioid_info['response'] = command
-                if event is not None:
-                    event.set()
+                event.set()
 
         elif isinstance(command, ca.EventAddResponse):
             try:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1359,12 +1359,12 @@ class VirtualCircuitManager:
         elif isinstance(command, ca.CreateChanResponse):
             pv = self.pvs[command.cid]
             chan = self.channels[command.cid]
-            pv.connection_state_changed('connected', chan)
             self.all_created_pvnames.append(pv.name)
             with pv.component_lock:
                 pv.channel = chan
                 cm = pv.circuit_manager
                 pv.channel_ready.set()
+            pv.connection_state_changed('connected', chan)
             # If we have just revived an existing PV whose
             # VirtualCircuit died and reconnected, we are now ready to
             # reinstate its Subsciprtions. If this is a new PV, it

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -40,8 +40,8 @@ from .util import RLock, Event, Telemetry
 
 
 print = partial(print, flush=True)
-debug_print = print
-# debug_print = (lambda *args, **kw: None)
+# debug_print = print
+debug_print = (lambda *args, **kw: None)
 
 
 CIRCUIT_DEATH_ATTEMPTS = 3

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -234,7 +234,7 @@ class PV:
     @property
     def connected(self):
         'Connection state'
-        return self._caproto_pv.connected
+        return self._caproto_pv.connected and self._connect_event.is_set()
 
     def force_connect(self, pvname=None, chid=None, conn=True, **kws):
         # not quite sure what this is for in pyepics
@@ -321,7 +321,8 @@ class PV:
             except Exception:
                 raise
             finally:
-                self._connect_event.set()
+                if connected:
+                    self._connect_event.set()
 
         # todo move to async connect logic
         for cb in self.connection_callbacks:

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -183,6 +183,7 @@ class PV:
         self.verbose = verbose
         self.auto_monitor = auto_monitor
         self.ftype = None
+        self._connected = False
         self._connect_event = threading.Event()
         self._state_lock = RLock(self.pvname + '/state_lock')
         self.connection_timeout = connection_timeout

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -13,6 +13,7 @@ from .client import (Context, SharedBroadcaster, AUTOMONITOR_MAXLENGTH,
 from caproto import (AccessRights, field_types, ChannelType,
                      CaprotoTimeoutError, CaprotoValueError,
                      CaprotoRuntimeError, CaprotoNotImplementedError)
+from .util import RLock
 
 
 __all__ = ('PV', 'get_pv', 'caget', 'caput')
@@ -183,7 +184,7 @@ class PV:
         self.auto_monitor = auto_monitor
         self.ftype = None
         self._connect_event = threading.Event()
-        self._state_lock = threading.RLock()
+        self._state_lock = RLock(self.pvname + '/state_lock')
         self.connection_timeout = connection_timeout
         self.default_count = count
         self._auto_monitor_sub = None

--- a/caproto/threading/pyepics_compat.py
+++ b/caproto/threading/pyepics_compat.py
@@ -13,7 +13,7 @@ from .client import (Context, SharedBroadcaster, AUTOMONITOR_MAXLENGTH,
 from caproto import (AccessRights, field_types, ChannelType,
                      CaprotoTimeoutError, CaprotoValueError,
                      CaprotoRuntimeError, CaprotoNotImplementedError)
-from .util import RLock
+from .util import RLock, Event
 
 
 __all__ = ('PV', 'get_pv', 'caget', 'caput')
@@ -184,7 +184,7 @@ class PV:
         self.auto_monitor = auto_monitor
         self.ftype = None
         self._connected = False
-        self._connect_event = threading.Event()
+        self._connect_event = Event(self.pvname + '/connect_event')
         self._state_lock = RLock(self.pvname + '/state_lock')
         self.connection_timeout = connection_timeout
         self.default_count = count

--- a/caproto/threading/util.py
+++ b/caproto/threading/util.py
@@ -55,9 +55,29 @@ if debug:
             self.wait_times.append([None, start, stop])
             return ret
 
+    class Telemetry:
+        def __init__(self, name):
+            super().__init__()
+            self.name = name
+            self.wait_times = []
+            all_events.append(self)
+            self.t0 = None
+            self.t1 = None
+
+        def record_time(self, t0, t1):
+            # f = io.StringIO()
+            # traceback.print_stack(file=f)
+            self.wait_times.append([None, t0, t1])
+
+        def __enter__(self):
+            self.t0 = time.time()
+
+        def __exit__(self, exc_type, exc_value, tb):
+            self.t1 = time.time()
+            self.wait_times.append(['', self.t0, self.t1])
+
     def show_wait_times(threshold, *, show_stack=False):
         for obj in all_locks + all_events:
-            print(obj.name)
             if isinstance(obj, _Lock):
                 types = [('hold', obj.hold_times),
                          ('acquire', obj.acquire_times)]
@@ -74,12 +94,12 @@ if debug:
                         continue
                     elapsed = stop - start
                     if elapsed >= threshold:
-                        print(f'+ {time_type} {elapsed:.3f}')
+                        print(f'+ {obj.name} {time_type} {elapsed:.3f}')
                         if show_stack and stack is not None:
                             print(f'Stack: {stack.getvalue()}')
                     total += elapsed
-                if total > 0.001:
-                    print(f'  -> {obj.name} {time_type} total={total:.3f}')
+                if total > 0.001 and len(list_) > 1:
+                    print(f'-> {obj.name} {time_type} total={total:.3f}')
 
 else:
     def RLock(name):

--- a/caproto/threading/util.py
+++ b/caproto/threading/util.py
@@ -99,7 +99,8 @@ if debug:
                             print(f'Stack: {stack.getvalue()}')
                     total += elapsed
                 if total > 0.001 and len(list_) > 1:
-                    print(f'-> {obj.name} {time_type} total={total:.3f}')
+                    print(f'-> {obj.name} {time_type} total={total:.3f} '
+                          f'count={len(list_)}')
 
 else:
     def RLock(name):

--- a/caproto/threading/util.py
+++ b/caproto/threading/util.py
@@ -3,7 +3,7 @@ import threading
 import time
 import traceback
 
-debug = True
+debug = False
 
 
 if debug:
@@ -111,6 +111,19 @@ else:
 
     def Event(name):
         return threading.Event()
+
+    class Telemetry:
+        def __init__(self, name):
+            super().__init__()
+
+        def record_time(self, t0, t1):
+            self.wait_times.append([None, t0, t1])
+
+        def __enter__(self):
+            ...
+
+        def __exit__(self, exc_type, exc_value, tb):
+            ...
 
     def show_wait_times(threshold):
         ...

--- a/caproto/threading/util.py
+++ b/caproto/threading/util.py
@@ -1,0 +1,49 @@
+import time
+import threading
+
+debug = True
+
+
+if debug:
+    all_locks = []
+
+    class _Lock:
+        def __init__(self, name):
+            self.times = []
+            self.name = name
+            all_locks.append(self)
+
+        def __enter__(self):
+            self.times.append([time.time()])
+            return self.lock.__enter__()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.times[-1].append(time.time())
+            return self.lock.__exit__(exc_type, exc_value, traceback)
+
+    def show_wait_times(threshold):
+        for lock in all_locks:
+            print(lock.name)
+            for item in lock.times:
+                try:
+                    start, stop = item
+                except ValueError:
+                    continue
+                elapsed = stop - start
+                if elapsed >= threshold:
+                    print(f'+ {elapsed:.3f}')
+
+    class RLock(_Lock):
+        def __init__(self, name):
+            super().__init__(name)
+            self.lock = threading.RLock()
+
+    class Lock(_Lock):
+        def __init__(self, name):
+            self.lock = threading.Lock()
+else:
+    def RLock(name):
+        return threading.RLock()
+
+    def Lock(name):
+        return threading.Lock()

--- a/stage_test.py
+++ b/stage_test.py
@@ -6,9 +6,9 @@ import ophyd
 pe = ophyd.load_cl('pyepics', False)
 ca = ophyd.load_cl('caproto', False)
 
-class TesterPyepics(Device):
-   a = Cpt(EpicsSignal, 'mtr1.OFF', cl=pe)
-   b = Cpt(EpicsSignal, 'mtr2.OFF', cl=pe)
+# class TesterPyepics(Device):
+#    a = Cpt(EpicsSignal, 'mtr1.OFF', cl=pe)
+#    b = Cpt(EpicsSignal, 'mtr2.OFF', cl=pe)
 
 class TesterCaproto(Device):
    a = Cpt(EpicsSignal, 'mtr1.OFF', cl=ca)
@@ -19,9 +19,9 @@ tc = TesterCaproto('sim:', name='tc')
 tc.stage_sigs['a'] = 1
 tc.stage_sigs['b'] = 1
 
-tp = TesterPyepics('sim:', name='tp')
-tp.stage_sigs['a'] = 1
-tp.stage_sigs['b'] = 1
+# tp = TesterPyepics('sim:', name='tp')
+# tp.stage_sigs['a'] = 1
+# tp.stage_sigs['b'] = 1
 
 
 if False:
@@ -35,7 +35,7 @@ if False:
 else:
     import logging
     # logging.getLogger('caproto').setLevel('DEBUG')
-    for i in range(10):
+    for _ in range(10):
         tc.stage(); tc.unstage()
     from caproto.threading.util import show_wait_times
-    show_wait_times(0.01)
+    show_wait_times(0.001)

--- a/stage_test.py
+++ b/stage_test.py
@@ -1,0 +1,41 @@
+from ophyd import Device, Component as Cpt, EpicsSignal
+import ophyd
+
+# ensure using: klauer/ophyd@load_cl for this test
+
+pe = ophyd.load_cl('pyepics', False)
+ca = ophyd.load_cl('caproto', False)
+
+class TesterPyepics(Device):
+   a = Cpt(EpicsSignal, 'mtr1.OFF', cl=pe)
+   b = Cpt(EpicsSignal, 'mtr2.OFF', cl=pe)
+
+class TesterCaproto(Device):
+   a = Cpt(EpicsSignal, 'mtr1.OFF', cl=ca)
+   b = Cpt(EpicsSignal, 'mtr2.OFF', cl=ca)
+
+
+tc = TesterCaproto('sim:', name='tc')
+tc.stage_sigs['a'] = 1
+tc.stage_sigs['b'] = 1
+
+tp = TesterPyepics('sim:', name='tp')
+tp.stage_sigs['a'] = 1
+tp.stage_sigs['b'] = 1
+
+
+if False:
+    import IPython.core.getipython
+    ipython = IPython.core.getipython.get_ipython()
+
+    print('pyepics')
+    ipython.magic("%timeit tp.stage(); tp.unstage()")
+    print('caproto')
+    ipython.magic("%timeit tc.stage(); tc.unstage()")
+else:
+    import logging
+    # logging.getLogger('caproto').setLevel('DEBUG')
+    for i in range(10):
+        tc.stage(); tc.unstage()
+    from caproto.threading.util import show_wait_times
+    show_wait_times(0.01)

--- a/stage_test.py
+++ b/stage_test.py
@@ -35,7 +35,7 @@ if False:
 else:
     import logging
     # logging.getLogger('caproto').setLevel('DEBUG')
-    for _ in range(10):
+    for _ in range(100):
         tc.stage(); tc.unstage()
     from caproto.threading.util import show_wait_times
     show_wait_times(0.001)


### PR DESCRIPTION
Here's the results as of 950e735 - after reducing unnecessary locking and introducing `TCP_NODELAY`:
```
$ pip install git+https://github.com/klauer/ophyd@load_cl
$ ipython stage_test.py

pyepics
2.39 ms ± 45.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
caproto
3.92 ms ± 175 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```