### PR TITLE
PERF: Be less careful about sending data in threading client

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1255,7 +1255,11 @@ class VirtualCircuitManager:
         # be send, and convert them to buffers.
         buffers_to_send = self.circuit.send(*commands)
         # Send bytes over the wire using some caproto utilities.
-        ca.send_all(buffers_to_send, self._socket_send)
+        if len(buffers_to_send) == 1:
+            b, = buffers_to_send
+            self.socket.sendall(b)
+        else:
+            ca.send_all(buffers_to_send, self._socket_send)
 
     def received(self, bytes_recv, address):
         """Receive and process and next command from the virtual circuit.


### PR DESCRIPTION
This fixes the 40ms deadlock on every PV durring staging.

The issue is that:
 - when not waiting for put, we send a 'Write' message
 - we send it in a safe way that we know how many bytes were sent
 - this requires use to get an ACK back at the tcp level from the
 server
 - but 'Write' does not send anything back and if there is nothing
 else going on, we do not get the ACK until the tcp stack times out
 and sends the ACK by its self

Switching to `socket.sendall` experimentally fixes the problem, but
may have consequences so only do it if there is only one buffer to
send.  May want to also limit by size?