### PR TITLE
Add an editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 79


### PR DESCRIPTION
This should tell vim/emacs/whatever to line-wrap at 79. Notice that
we only _enforce_ wrapping at 115 to allow for the occasional situation
where a longer line is easier to read. But we encourage wrapping at 79.