### PR TITLE
FIX: only propose changing the alarm state if it is actually changed

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -658,9 +658,9 @@ class ChannelData:
 
     def _collect_alarm(self):
         out = {}
-        if self._status is not None:
+        if self._status is not None and self._status != self.alarm.status:
             out['status'] = self._status
-        if self._severity is not None:
+        if self._severity is not None and self._status != self.alarm.status:
             out['severity'] = self._severity
 
         self._clear_cached_alarms()

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -26,7 +26,7 @@ CA_SERVER_PORT = 5064  # just a default
 
 # Make a dict to hold our tcp sockets.
 sockets = {}
-circuits = {}
+global_circuits = {}
 
 _permission_to_block = []  # mutable state shared by block and interrupt
 
@@ -131,10 +131,10 @@ def make_channel(pv_name, udp_sock, priority, timeout):
     log = logging.getLogger(f'caproto.ch.{pv_name}.{priority}')
     address = search(pv_name, udp_sock, timeout)
     try:
-        circuit = circuits[(address, priority)]
+        circuit = global_circuits[(address, priority)]
     except KeyError:
 
-        circuit = circuits[(address, priority)] = ca.VirtualCircuit(
+        circuit = global_circuits[(address, priority)] = ca.VirtualCircuit(
             our_role=ca.CLIENT,
             address=address,
             priority=priority)
@@ -174,7 +174,7 @@ def make_channel(pv_name, udp_sock, priority, timeout):
     except BaseException:
         sockets[chan.circuit].close()
         del sockets[chan.circuit]
-        del circuits[(chan.circuit.address, chan.circuit.priority)]
+        del global_circuits[(chan.circuit.address, chan.circuit.priority)]
         raise
     return chan
 
@@ -265,7 +265,7 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
         finally:
             sockets[chan.circuit].close()
             del sockets[chan.circuit]
-            del circuits[(chan.circuit.address, chan.circuit.priority)]
+            del global_circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def subscribe(pv_name, priority=0, data_type=None, data_count=None,
@@ -457,7 +457,7 @@ def block(*subscriptions, duration=None, timeout=1, force_int_enums=False,
                 sockets[chan.circuit].settimeout(timeout)
                 sockets[chan.circuit].close()
                 del sockets[chan.circuit]
-                del circuits[(chan.circuit.address, chan.circuit.priority)]
+                del global_circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def _write(chan, data, metadata, timeout, data_type, notify):
@@ -562,7 +562,7 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
         finally:
             sockets[chan.circuit].close()
             del sockets[chan.circuit]
-            del circuits[(chan.circuit.address, chan.circuit.priority)]
+            del global_circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def read_write_read(pv_name, data, *, notify=False,
@@ -648,7 +648,7 @@ def read_write_read(pv_name, data, *, notify=False,
         finally:
             sockets[chan.circuit].close()
             del sockets[chan.circuit]
-            del circuits[(chan.circuit.address, chan.circuit.priority)]
+            del global_circuits[(chan.circuit.address, chan.circuit.priority)]
     return initial, res, final
 
 

--- a/caproto/sync/client.py
+++ b/caproto/sync/client.py
@@ -173,6 +173,8 @@ def make_channel(pv_name, udp_sock, priority, timeout):
 
     except BaseException:
         sockets[chan.circuit].close()
+        del sockets[chan.circuit]
+        del circuits[(chan.circuit.address, chan.circuit.priority)]
         raise
     return chan
 
@@ -262,6 +264,8 @@ def read(pv_name, *, data_type=None, timeout=1, priority=0, notify=True,
                 send(chan.circuit, chan.clear())
         finally:
             sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def subscribe(pv_name, priority=0, data_type=None, data_count=None,
@@ -452,6 +456,8 @@ def block(*subscriptions, duration=None, timeout=1, force_int_enums=False,
             for chan in channels.values():
                 sockets[chan.circuit].settimeout(timeout)
                 sockets[chan.circuit].close()
+                del sockets[chan.circuit]
+                del circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def _write(chan, data, metadata, timeout, data_type, notify):
@@ -555,6 +561,8 @@ def write(pv_name, data, *, notify=False, data_type=None, metadata=None,
                 send(chan.circuit, chan.clear())
         finally:
             sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del circuits[(chan.circuit.address, chan.circuit.priority)]
 
 
 def read_write_read(pv_name, data, *, notify=False,
@@ -639,6 +647,8 @@ def read_write_read(pv_name, data, *, notify=False,
                 send(chan.circuit, chan.clear())
         finally:
             sockets[chan.circuit].close()
+            del sockets[chan.circuit]
+            del circuits[(chan.circuit.address, chan.circuit.priority)]
     return initial, res, final
 
 


### PR DESCRIPTION
This prevents subscriptions for being processed for all signal that
share an alarm if the alarm state has not actually changed.