### PR TITLE
TST: allow toggling very-verbose -vvv when running example IOCs

### DIFF
--- a/caproto/tests/conftest.py
+++ b/caproto/tests/conftest.py
@@ -57,7 +57,7 @@ def assert_array_almost_equal(arr1, arr2):
 
 
 def run_example_ioc(module_name, *, request, pv_to_check, args=None,
-                    stdin=None, stdout=None, stderr=None):
+                    stdin=None, stdout=None, stderr=None, very_verbose=True):
     '''Run an example IOC by module name as a subprocess
 
     Parameters
@@ -75,7 +75,7 @@ def run_example_ioc(module_name, *, request, pv_to_check, args=None,
     else:
         logger.debug(f'Running {module_name}')
 
-    if '-vvv' not in args:
+    if '-vvv' not in args and very_verbose:
         args = list(args) + ['-vvv']
 
     os.environ['COVERAGE_PROCESS_START'] = '.coveragerc'


### PR DESCRIPTION
Simple tweak - allow toggling of `-vvv` for example IOCs.

This utility function is now used in ophyd as well, so it's nice to have some additional control over the output.