### PR TITLE
API: Deprecate color_logs in favor of set_handler.

### DIFF
--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -13,7 +13,7 @@ Python session, do not import this module; instead import caproto.sync.client.
 import argparse
 from datetime import datetime
 import logging
-from .. import ChannelType, color_logs, field_types, __version__
+from .. import ChannelType, set_handler, field_types, __version__
 from ..sync.client import read
 from .._utils import ShowVersionAction
 
@@ -79,7 +79,7 @@ def main():
                         help="Show caproto version and exit.")
     args = parser.parse_args()
     if args.no_color:
-        color_logs(False)
+        set_handler(color=False)
     if args.verbose:
         logging.getLogger(f'caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -16,7 +16,7 @@ import functools
 import logging
 import time
 from ..sync.client import subscribe, block
-from .. import SubscriptionType, color_logs, __version__
+from .. import SubscriptionType, set_handler, __version__
 from .._utils import ShowVersionAction
 
 
@@ -67,7 +67,7 @@ def main():
                         help="Show caproto version and exit.")
     args = parser.parse_args()
     if args.no_color:
-        color_logs(False)
+        set_handler(color=False)
     if args.verbose:
         logging.getLogger('caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')

--- a/caproto/commandline/put.py
+++ b/caproto/commandline/put.py
@@ -15,8 +15,8 @@ import ast
 import sys
 from datetime import datetime
 import logging
+from .. import set_handler, __version__
 from ..sync.client import read_write_read
-from .. import color_logs, __version__
 from .._utils import ShowVersionAction
 
 
@@ -77,7 +77,7 @@ def main():
                         help="Show caproto version and exit.")
     args = parser.parse_args()
     if args.no_color:
-        color_logs(False)
+        set_handler(color=False)
     if args.verbose:
         logging.getLogger(f'caproto.ch').setLevel('DEBUG')
         logging.getLogger(f'caproto.ctx').setLevel('DEBUG')

--- a/caproto/commandline/repeater.py
+++ b/caproto/commandline/repeater.py
@@ -15,7 +15,7 @@ import argparse
 import logging
 import os
 from ..sync.repeater import run
-from .. import color_logs, __version__
+from .. import set_handler, __version__
 from .._utils import ShowVersionAction
 
 
@@ -43,7 +43,7 @@ EPICS_CA_REPEATER_PORT. It defaults to the standard 5065. The current value is
                         help="Show caproto version and exit.")
     args = parser.parse_args()
     if args.no_color:
-        color_logs(False)
+        set_handler(color=False)
     if args.verbose and args.verbose > 2:
         logging.getLogger('caproto').setLevel('DEBUG')
     else:

--- a/doc/source/loggers.rst
+++ b/doc/source/loggers.rst
@@ -61,30 +61,29 @@ Here is the complete list of loggers used by caproto.
 Logging Handlers
 ================
 
-At import time, caproto adds a logging stream handler
-``caproto.color_log_handler`` to the ``'caproto'`` logger, which uses ANSI
-color codes to color-code the log messages by log level.
+By default, caproto prints log messages to the standard out by adding a
+:class:`logging.StreamHandler` to the ``'caproto'`` logger at import time. You
+can, of course, configure the handlers manually in the standard fashion
+supported by Python. But a convenience function :func:`caproto.set_handler`,
+makes it easy to address to common cases.
 
-To conveniently switch to a version without the colors:
-
-.. code-block:: python
-
-    caproto.color_logs(False)  # color_log_handler -> plain_log_handler
-
-You can, of course, configure the handlers manually in the standard fashion
-supported by Python, using ``logging.getLogger('caproto').handlers``. For
-example, to remove caproto's default handler and write to a file instead of the
-standard out:
+To direct the messages to a file instead of the standard out:
 
 .. code-block:: python
 
-   import logging
-   import caproto
-   from caproto._log import LogFormatter, color_log_format, log_date_format
+    import caproto
 
-   handler = logging.FileHandler(YOUR_FILEPATH)
-   handler.setFormatter(
-       LogFormatter(color_log_format, datefmt=log_date_format))
-   log = logging.getLogger('caproto')
-   log.handlers.clear()
-   log.addHandler(handler)
+    caproto.set_handler(file='caproto.log')
+
+A file object (anything that implements a ``write`` method) is also accepted,
+as in ``caproto.set_handler(file=open('caproto.log'))``.
+
+
+The default handler uses ANSI color codes to color-code the log messages by log
+level. To disable the color codes:
+
+.. code-block:: python
+
+    caproto.set_handler(color=False)
+
+.. autofunction:: caproto.set_handler


### PR DESCRIPTION
We copied the caproto logging utilities to bluesky and improved on it there,
thanks mostly to input from @mrakitin. This PR copies those improvement back
to caproto.