### PR TITLE
DEBUG-log read/write request and responses always

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1646,7 +1646,7 @@ class PV:
         # Stash the ioid to match the response to the request.
 
         event = threading.Event()
-        ioid_info = dict(event=event, pv=self)
+        ioid_info = dict(event=event, pv=self, request=command)
         if callback is not None:
             ioid_info['callback'] = callback
 
@@ -1722,7 +1722,7 @@ class PV:
                              data_type=data_type, data_count=data_count)
         if notify:
             event = threading.Event()
-            ioid_info = dict(event=event, pv=self)
+            ioid_info = dict(event=event, pv=self, request=command)
             if callback is not None:
                 ioid_info['callback'] = callback
 

--- a/doc/source/loggers.rst
+++ b/doc/source/loggers.rst
@@ -67,20 +67,7 @@ can, of course, configure the handlers manually in the standard fashion
 supported by Python. But a convenience function :func:`caproto.set_handler`,
 makes it easy to address to common cases.
 
-To direct the messages to a file instead of the standard out:
-
-.. code-block:: python
-
-    import caproto
-
-    caproto.set_handler(file='caproto.log')
-
-A file object (anything that implements a ``write`` method) is also accepted,
-as in ``caproto.set_handler(file=open('caproto.log'))``.
-
-
-The default handler uses ANSI color codes to color-code the log messages by log
-level. To disable the color codes:
+See the Examples section below.
 
 .. code-block:: python
 


### PR DESCRIPTION
This refines the work in #370 to ensure that _all_ read/write requests and responses, including those with `wait=False` and those initiated via a batched request, generate DEBUG messages in the coresponding PV/channel logger.