### PR TITLE
STY: flake8 found an over-indented method block

### DIFF
--- a/caproto/_data.py
+++ b/caproto/_data.py
@@ -667,7 +667,7 @@ class ChannelData:
         return out
 
     def _clear_cached_alarms(self):
-            self._status = self._severity = None
+        self._status = self._severity = None
 
     def __len__(self):
         try:


### PR DESCRIPTION
New flake8 versions find over-indented method blocks now, apparently. 

Discovered in #436 travis results; blame indicates this has been there for a few months.