### PR TITLE
TST: turn down iterations

### DIFF
--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -374,7 +374,7 @@ def thread_count(request):
     return request.param
 
 
-@pytest.fixture(params=[f'iter{i}' for i in range(1, 3)])
+@pytest.fixture(params=[f'iter{i}' for i in [1]])
 def multi_iterations(request):
     return request.param
 


### PR DESCRIPTION
These iterations are to expose a subtle race condition in the
threaded client, however they are not useful for actually debugging it
anymore and my repeating them we are pushing up the odds that at least
on run on CI fails erroneously.