### PR TITLE
CI: add R3-14 to the azure test matrix; bring travis/azure up to epics-on-travis 0.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,13 @@ python:
 
 env:
   matrix:
-    - BASE=R3.14.12.6 INSTALL_NUMPY=0 \
-      PVA= BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-9 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.7/epics-ci-0.7_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2 \
-    - BASE=R3.14.12.6 INSTALL_NUMPY=1 \
-      PVA= BUSY=1-6-1 SEQ=2.2.5 ASYN=4-32 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-9 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.7/epics-ci-0.7_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2 \
-    - BASE=R7.0.1.1 INSTALL_NUMPY=1 \
-      PVA= BUSY=1-7 SEQ=2.2.5 ASYN=4-33 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.7/epics-ci-0.7_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2 \
-      PUBLISH_DOCS=1
-    - BASE=R7.0.1.1 INSTALL_NUMPY=0 \
-      PVA= BUSY=1-7 SEQ=2.2.5 ASYN=4-33 CALC=3-7 AUTOSAVE=5-9 SSCAN=2-11-1 MOTOR=6-10 AREADETECTOR=3-2 \
-      PACKAGED_DEPS=0.7/epics-ci-0.7_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2 \
+    - ID=R314_ARRAY INSTALL_NUMPY=0 PACKAGED_DEPS=0.8.2/epics-ci-0.8.2_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2
+    - ID=R314_NUMPY INSTALL_NUMPY=1 PACKAGED_DEPS=0.8.2/epics-ci-0.8.2_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2
+    - ID=R7_NUMPY INSTALL_NUMPY=1 PUBLISH_DOCS=1 PACKAGED_DEPS=0.8.2/epics-ci-0.8.2_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2
+    - ID=R7_ARRAY INSTALL_NUMPY=0 PACKAGED_DEPS=0.8.2/epics-ci-0.8.2_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2
 
   global:
     - secure: "Hnz9c6x13kaAc7IqH4/wJWNel2rzEC8/x0KhFoGLVLHjmiH1LMmpGh/P5CPADlmKS80WFz4vhJ0YtSjtHCPI+9Y2aBGn8z732WM86OyGHITviCMTxtyVZfRFCkOAVlU0qpIyWu4p0rEfxrXCztSKE4bBO/wWnFhGGw9CJROnFhJwoJlbI9i28zscyeGsdqHNUfXHkyUAN3c3LKoYZgnJco5HiHLwXVvsy3DMkvOizLgslf6lrHwnQOT1F49ShgPcGGWpkuRARXkGII7lB0LOn2TBoTzmhgjoC3OmC4nZGJfzitwH9+nHc+iJ3mTlshsXb366B/D5TNVIL/4rzYV8zw49DogQIWYtECK4/z7fOzG61yCU33b3aeXU2OI4k5eZ2qN3gp3KQ4+PWyCMTHsBVgs6o49K1HWtFuuFLuhUPT4FVs2Pzz6yTka9NUukPO1LoTeQAUvGxRbc/15CjIWXtqqzEGmlPi8AFEo2kw33EtTawMU9w8nzAfdk5DX28Qcuzh9XA9nVUD0j7Rum7nGY1f5+icXh0FsOuP1uHt82bXIYvw3rey3RkWcqVcniJXlkq0bAZM/ZSXWX5VHyQ2e7C4kxCdnzVqjgtlGT2ARSlD6o8FKKRKTAKD7kQ9ajTjZHRhO+xbvP+X4K9GlbGvPyU9bnDFa14fXBJS4dTMd8GgQ="
-
-# matrix:
-#   fast_finish: true
-#   allow_failures:
-#     - env: BASE=3.16
 
 matrix:
   exclude:
@@ -59,8 +45,9 @@ before_install:
 
   - git fetch --unshallow
   - export CI_SCRIPTS=${TRAVIS_BUILD_DIR}/.ci/ci-scripts
-  - source ${CI_SCRIPTS}/epics-config.sh
   - bash .ci/install-from-release.sh "https://github.com/klauer/epics-on-travis/releases/download/${PACKAGED_DEPS}"
+  - source $HOME/epics/versions.sh
+  - source ${CI_SCRIPTS}/epics-config.sh
   - bash ${CI_SCRIPTS}/run-epics-iocs-on-procserv.sh
   - pip install pyepics numpy
 
@@ -91,7 +78,7 @@ script:
   - coverage run --parallel-mode run_tests.py -k 'not bench'  --benchmark-disable -v
   - coverage combine --append
 
-  - export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE}
+  - export ASV_ENV_NAME=${TRAVIS_PYTHON_VERSION}_${BASE_VER}
   - |
     if [ $INSTALL_NUMPY ]
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_install:
 
   - git fetch --unshallow
   - export CI_SCRIPTS=${TRAVIS_BUILD_DIR}/.ci/ci-scripts
+  - install -d $HOME/epics $HOME/epics/iocs $HOME/epics/support $HOME/epics/base
   - bash .ci/install-from-release.sh "https://github.com/klauer/epics-on-travis/releases/download/${PACKAGED_DEPS}"
   - source $HOME/epics/versions.sh
   - source ${CI_SCRIPTS}/epics-config.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,5 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
 # vi: sw=2 ts=2 sts=2 expandtab
 
-variables:
-    EPICS_ON_TRAVIS_TAG: '0.8.1'
-    EPICS_ON_TRAVIS_PKG: '0.8.1/epics-ci-0.8.1_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2'
-  
 jobs:
 
 - job: 'Test'
@@ -15,17 +7,28 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   strategy:
     matrix:
-      Python36:
+      Python36_R314:
         python.version: '3.6'
-      Python37:
+        epics.on.travis.pkg: '0.8.2/epics-ci-0.8.2_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2'
+      Python37_R314:
         python.version: '3.7'
-    maxParallel: 4
+        epics.on.travis.pkg: '0.8.2/epics-ci-0.8.2_R3.14.12.6_pva_areadetector3-2_motor6-9.tar.bz2'
+      Python36_R7:
+        python.version: '3.6'
+        epics.on.travis.pkg: '0.8.2/epics-ci-0.8.2_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2'
+      Python37_R7:
+        python.version: '3.7'
+        epics.on.travis.pkg: '0.8.2/epics-ci-0.8.2_R7.0.1.1_pva_areadetector3-2_motor6-10.tar.bz2'
 
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
+
+  - bash: |
+      git submodule update --init --recursive
+    displayName: 'Checkout submodules'
 
   - bash: |
       pushd /home
@@ -40,10 +43,21 @@ jobs:
       env
       pwd
       cp azure_env.sh $HOME
-      # this does not yet work:
-      echo 'source $HOME/azure_env.sh' >> "$HOME/.bashrc"
-      echo 'source $HOME/.bashrc' >> "$HOME/.bash_profile"
-    displayName: 'Show the environment'
+    displayName: 'Configure the environment'
+
+  - bash: |
+      export CI_TOP="${BUILD_REPOSITORY_LOCALPATH}/.ci"
+      export EPICS_ON_TRAVIS_PKG="$(epics.on.travis.pkg)"
+      source $HOME/azure_env.sh
+      bash ${CI_TOP}/install-from-release.sh "${EPICS_ON_TRAVIS_URL}"
+    displayName: 'Install EPICS dependencies'
+
+  - bash: |
+      echo "EPICS versions are as follows:"
+      source $HOME/azure_env.sh
+      echo "Base version: ${BASE_VER}"
+      cat $HOME/epics/versions.sh
+    displayName: 'Show EPICS versions'
 
   - bash: |
       python -m pip install --upgrade pip
@@ -56,14 +70,6 @@ jobs:
   - bash: |
       pip install .
     displayName: 'Install caproto'
-
-  - bash: |
-      export CI_TOP="$HOME/ci"
-      # git clone --single-branch --branch ${EPICS_ON_TRAVIS_TAG} --depth 1 https://github.com/klauer/epics-on-travis ${CI_TOP}
-      git clone --single-branch --branch master --depth 1 https://github.com/klauer/epics-on-travis ${CI_TOP}
-      source $HOME/azure_env.sh
-      bash ${CI_TOP}/install-from-release.sh "${EPICS_ON_TRAVIS_URL}"
-    displayName: 'Install EPICS dependencies'
 
   - bash: |
       source $HOME/azure_env.sh

--- a/azure_env.sh
+++ b/azure_env.sh
@@ -1,9 +1,9 @@
-export CI_TOP="$HOME/ci"
+export CI_TOP="$BUILD_REPOSITORY_LOCALPATH/.ci"
 
 pushd $CI_TOP
 
 cat > "epics_on_travis_custom_env.sh" <<'EOF'
-export TRAVIS_BUILD_DIR="${HOME}"
+export TRAVIS_BUILD_DIR="${BUILD_REPOSITORY_LOCALPATH}"
 export EPICS_CAS_INTF_ADDR_LIST=0.0.0.0
 export EPICS_CA_ADDR_LIST=255.255.255.255
 export EPICS_CAS_BEACON_ADDR_LIST=$EPICS_CA_ADDR_LIST
@@ -11,6 +11,12 @@ export EPICS_CA_AUTO_ADDR_LIST=NO
 export EPICS_CAS_AUTO_BEACON_ADDR_LIST=NO
 export EPICS_ON_TRAVIS_URL="https://github.com/klauer/epics-on-travis/releases/download/${EPICS_ON_TRAVIS_PKG}"
 EOF
+
+if [ -f "$HOME/epics/versions.sh" ]; then
+    set -x
+    . $HOME/epics/versions.sh
+    set +x
+fi
 
 source setup_local_dev_env.sh
 popd

--- a/caproto/tests/test_pyepics_compat.py
+++ b/caproto/tests/test_pyepics_compat.py
@@ -514,7 +514,7 @@ def test_get1(pvnames):
     assert int(cval) == val
 
 
-@pytest.mark.xfail(os.environ.get('BASE') in ('R3.16.1', 'R7.0.1.1'),
+@pytest.mark.xfail(os.environ.get('BASE_VER') in ('R3.16.1', 'R7.0.1.1'),
                    reason='known issues with simulator on some BASE versions')
 def test_get_string_waveform(pvnames, simulator):
     print('String Array: \n')
@@ -626,7 +626,7 @@ def test_putwait(pvnames):
     assert count > 3
 
 
-@pytest.mark.xfail(os.environ.get('BASE') in ('R3.16.1', 'R7.0.1.1'),
+@pytest.mark.xfail(os.environ.get('BASE_VER') in ('R3.16.1', 'R7.0.1.1'),
                    reason='known issues with simulator on some BASE versions')
 def test_get_callback(pvnames, simulator):
     print("Callback test:  changing PV must be updated\n")
@@ -719,7 +719,7 @@ def test_waveform_get_with_count_arg(pvnames):
     assert len(val) == wf.nelm
 
 
-@pytest.mark.xfail(os.environ.get('BASE') in ('R3.16.1', 'R7.0.1.1'),
+@pytest.mark.xfail(os.environ.get('BASE_VER') in ('R3.16.1', 'R7.0.1.1'),
                    reason='known issues with simulator on some BASE versions')
 def test_waveform_callback_with_count_arg(pvnames, simulator):
     values = []
@@ -803,7 +803,7 @@ def testEnumPut(pvnames):
     assert pv.get(as_string=True) == 'Stop'
 
 
-@pytest.mark.xfail(os.environ.get('BASE') in ('R3.16.1', 'R7.0.1.1'),
+@pytest.mark.xfail(os.environ.get('BASE_VER') in ('R3.16.1', 'R7.0.1.1'),
                    reason='known issues with simulator on some BASE versions')
 def test_DoubleVal(pvnames, simulator):
     pvn = pvnames.double_pv

--- a/setup_local_dev_env.sh
+++ b/setup_local_dev_env.sh
@@ -22,16 +22,6 @@ else
     export EPICS_CA_ADDR_LIST=127.255.255.255
     export EPICS_CA_AUTO_ADDR_LIST=NO
     export EPICS_CA_MAX_ARRAY_BYTES=10000000
-    # example build matrix variables
-    export BASE=R3.14.12.6
-    export BUSY=1-6-1
-    export SEQ=2.2.5
-    export ASYN=4-31
-    export CALC=R3-6-1
-    export MOTOR=6-9
 
     source ${TRAVIS_BUILD_DIR}/.ci/epics-config.sh
 fi
-
-export |grep EPIC
-echo "BASE=${BASE} PVA=${PVA}"


### PR DESCRIPTION
* R3-14 now in azure test matrix, along with R7 (3.6, 3.7)
* epics-on-travis is updated to 0.8.2 with some miscellaneous fixes and clean-ups
* `versions.sh` now provided with epics-on-travis individual releases, significantly cleaning up test matrix environment variables

Notes
------
* `setup_local_dev_env.sh` should be revisited at some point
* R3-15, R3-16 could easily be added to azure if desirable