### PR TITLE
ENH: Add time_since_last_heard to Broadcaster.

### DIFF
--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -691,3 +691,12 @@ def test_events_off_and_on(ioc, context):
             time.sleep(0.2)
 
     assert monitor_values[1:] == [1, 2, 3, 6, 7, 8, 9]
+
+
+def test_time_since_last_heard(context, ioc):
+    pv, = context.get_pvs(ioc.pvs['str'])
+    pv.wait_for_connection(timeout=10)
+    time.sleep(1)
+    address, t = context.broadcaster.time_since_last_heard().items()
+    assert address  == pv.circuit_manager.address
+    assert 0 < t < 10

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -698,5 +698,5 @@ def test_time_since_last_heard(context, ioc):
     pv.wait_for_connection(timeout=10)
     time.sleep(1)
     address, t = context.broadcaster.time_since_last_heard().items()
-    assert address  == pv.circuit_manager.address
+    assert address == pv.circuit_manager.address
     assert 0 < t < 10

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -698,5 +698,5 @@ def test_time_since_last_heard(context, ioc):
     pv.wait_for_connection(timeout=10)
     time.sleep(1)
     (address, t), = context.broadcaster.time_since_last_heard().items()
-    assert address == pv.circuit_manager.address
+    assert address == pv.circuit_manager.circuit.address
     assert 0 < t < 10

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -697,6 +697,6 @@ def test_time_since_last_heard(context, ioc):
     pv, = context.get_pvs(ioc.pvs['str'])
     pv.wait_for_connection(timeout=10)
     time.sleep(1)
-    address, t = context.broadcaster.time_since_last_heard().items()
+    (address, t), = context.broadcaster.time_since_last_heard().items()
     assert address == pv.circuit_manager.address
     assert 0 < t < 10

--- a/caproto/tests/test_threading_client.py
+++ b/caproto/tests/test_threading_client.py
@@ -700,3 +700,4 @@ def test_time_since_last_heard(context, ioc):
     (address, t), = context.broadcaster.time_since_last_heard().items()
     assert address == pv.circuit_manager.circuit.address
     assert 0 < t < 10
+    pv.time_since_last_heard() - t < 10  # wide tolerance here for slow CI

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -689,7 +689,7 @@ class SharedBroadcaster:
 
         If the server fails to send a Beacon on schedule *and* fails to reply to
         an Echo, the server is assumed dead. A warning is issued, and all PVs
-        are disconnected to initiate reconnection.
+        are disconnected to initiate a reconnection attempt.
         """
         return {address: time.monotonic() - t for address, t in self._last_heard.items()}
 

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -687,7 +687,7 @@ class SharedBroadcaster:
         ``EPICS_CA_CONN_TMO`` (default 30 seconds unless overriden by that
         environment variable) if the server is healthy.
 
-        If the server fails to send a Beaon on schedule *and* fails to reply to
+        If the server fails to send a Beacon on schedule *and* fails to reply to
         an Echo, the server is assumed dead. A warning is issued, and all PVs
         are disconnected to initiate reconnection.
         """

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -1894,6 +1894,11 @@ class PV:
         for sub in self.subscriptions.values():
             sub.clear()
 
+    @ensure_connected
+    def time_since_last_heard(self, timeout=PV_DEFAULT_TIMEOUT):
+        address = self.circuit_manager.circuit.address
+        return self.context.broadcaster.time_since_last_heard()[address]
+
     # def __hash__(self):
     #     return id((self.context, self.circuit_manager, self.name))
 

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -356,11 +356,18 @@ the most recent update and then any future updates.
 Server Health Check
 -------------------
 
-To check how long it has been since each known server was last heard from, use:
+To check how much time has passed (in seconds) since each known server was last
+heard from, use:
 
 .. code-block:: python
 
    ctx.broadcaster.time_since_last_heard()
+
+As a convenience, check on the server connected to a specific PV using:
+
+.. code-block:: python
+
+   x.time_since_last_heard()
 
 See the :meth:`SharedBroadcaster.time_since_last_heard` API documentation below
 for details.

--- a/doc/source/threading-client.rst
+++ b/doc/source/threading-client.rst
@@ -353,6 +353,18 @@ the most recent update and then any future updates.
    ...
    x.circuit_manager.events_on()
 
+Server Health Check
+-------------------
+
+To check how long it has been since each known server was last heard from, use:
+
+.. code-block:: python
+
+   ctx.broadcaster.time_since_last_heard()
+
+See the :meth:`SharedBroadcaster.time_since_last_heard` API documentation below
+for details.
+
 .. _threading_loggers:
 
 Loggers for Debugging


### PR DESCRIPTION
@brunoseivam's post over in pyepics got me thinking about how to reuse
the beacon and echo information we are already collecting to expose a
"healthcheck" feature in caproto.

This is what it looks like when we are checking in on one healthy server and
one server that has died since we first connected to it.

```python

In [2]: from caproto.threading.client import Context

In [3]: ctx = Context()

In [4]: pvs = ctx.get_pvs('rpi:color', 'random_walk:x', 'random_walk:dt')

<some time later>

In [34]: ctx.broadcaster.time_since_last_heard()
Out[34]: 
{('192.168.86.245', 50421): 31.009815337019973,
 ('192.168.86.21', 5064): 27.976911116042174}

In [35]: ctx.broadcaster.time_since_last_heard()
Out[35]: 
{('192.168.86.245', 50421): 1.173450144007802,  # <-- This server just sent a beacon
 ('192.168.86.21', 5064): 29.195258807973005}

In [36]: ctx.broadcaster.time_since_last_heard()
Out[36]: 
{('192.168.86.245', 50421): 2.3499802510486916,
 ('192.168.86.21', 5064): 30.37178905296605}  # <-- This server is starting to look dead.
```

It is also useful to view this information "blown up" by PV.

```python
In [7]: {pv.name: ctx.broadcaster.time_since_last_heard()[pv.circuit_manager.circuit.address] for pv in ctx.pvs.values()}
Out[7]: 
{'random_walk:dt': 3.0864934510318562,
 'rpi:color': 7.46186305989977,
 'random_walk:x': 3.0865017119795084}
```

If you have thoughts on how to make this more useful @brunoseivam, I'm
interested.