### PR TITLE
FIX: Always raise ValidationError when deserialization fails.

### DIFF
--- a/caproto/sync/shark.py
+++ b/caproto/sync/shark.py
@@ -163,7 +163,7 @@ def sniff_version_header(header):
     if header.parameter1 == 1:
         return VersionResponse
     else:
-        raise ValueError("Unidentifiable command.")
+        raise ValidationError("Unidentifiable command.")
 
 
 def sniff_search_header(header):


### PR DESCRIPTION
This was caught when trying to use caproto-shark at the SIX beamline. The
symptom was:

```py
Traceback (most recent call last):
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/sync/shark.py", line 234, in infer_command_class
    return one_way_commands[id_]
KeyError: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda_envs/collection-2019-1.0-six/bin/caproto-shark", line 11, in <module>
    sys.exit(main())
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/commandline/shark.py", line 39, in main
    for namespace in shark(sys.stdin.buffer):
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/sync/shark.py", line 279, in shark
    data, command, _ = read_from_bytestream(data)
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/sync/shark.py", line 113, in read_from_bytestream
    class_ = infer_command_class(header)
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/sync/shark.py", line 237, in infer_command_class
    return sniffers[id_](header)
  File "/opt/conda_envs/collection-2019-1.0-six/lib/python3.6/site-packages/caproto/sync/shark.py", line 166, in sniff_version_header
    raise ValueError("Unidentifiable command.")
ValueError: Unidentifiable command.
```