### PR TITLE
Support for CLI output formatting arguments in 'get.py'

### DIFF
--- a/caproto/commandline/cli_print_formats.py
+++ b/caproto/commandline/cli_print_formats.py
@@ -21,10 +21,6 @@ class _DataPrintFormat:
         #                                      from the server as string
         self.no_brackets = False             # Print data as scalar (no brackets)
 
-    def is_set(self):
-        ''' Returns True if format string is not empty '''
-        return len(self.format) > 0
-
 
 def _clean_args_for_group(args_parsed=None, group_args=None, group_attrs=None):
     '''
@@ -211,7 +207,7 @@ def format_str_adjust(format_str=None, data_fmt=None):
     return format_str
 
 
-def print_response_data(data=None, data_fmt=None):
+def format_response_data(data=None, data_fmt=None):
     '''
     Prints data contained in iterable object 'data' to a string according to format specifications 'data_fmt'
     Returns a string containing printed data.

--- a/caproto/commandline/cli_print_formats.py
+++ b/caproto/commandline/cli_print_formats.py
@@ -1,0 +1,248 @@
+
+'''
+This module contains functions for formatting data output for CLI utilities
+(get.py and monitor.py). Format is selected based on command-line arguments.
+'''
+
+import numbers
+import sys
+import re
+
+
+class _DataPrintFormat:
+
+    def __init__(self):
+        self.format = ""
+        self.prefix = ""
+        self.separator = None
+        self.float_round = False    # floating point data value
+        #                             must be rounded to the nearest integer (long)
+        self.float_server_precision = False  # The floating point data value must be requested
+        #                                      from the server as string
+        self.no_brackets = False             # Print data as scalar (no brackets)
+
+    def is_set(self):
+        ''' Returns True if format string is not empty '''
+        return len(self.format) > 0
+
+
+def _clean_args_for_group(args_parsed=None, group_args=None, group_attrs=None):
+    '''
+    Cleans (sets to None) attributes of class 'args_parsed'. The only attribute that is
+    left corresponds to the argument that is specified last in the command line (sys.argv)
+
+    args_parsed - the class with attributes holding values of command line parameters
+    group_args - the list of the arguments in the group (ex. ["-0x", "-0o", "-0b"])
+    group_attrs - the list of corresponding attributes of 'args_parsed':
+                                                   ["int_0x", "int_0o", "int_0b"]
+    '''
+
+    if args_parsed is None or group_args is None or group_attrs is None:
+        return
+
+    if len(group_args) != len(group_attrs):
+        return
+
+    sa = sys.argv
+
+    arg_selected = None
+    for ag in reversed(sa):
+        for arg in group_args:
+            # Select appropriate regular expression for comparing arguments
+            reg_expr = "^{}$"  # Default is perfect match (typically for argument
+            #                    that starts with --)
+            # If the argument starts with '-', then match the beginning of the string
+            if len(ag) > 1 and ag[0] == '-' and ag[1] != '-':
+                reg_expr = "^{}.*"
+
+            p = re.compile(reg_expr.format(arg))
+            if p.match(ag) is not None:
+                arg_selected = arg
+                break
+
+        if arg_selected is not None:
+            break
+
+    if arg_selected is not None:
+        n_arg = group_args.index(arg_selected)
+        for i, attr in enumerate(group_attrs):
+            if i != n_arg and hasattr(args_parsed, attr):
+                setattr(args_parsed, attr, None)
+
+
+def clean_format_args(args=None):
+    '''
+    The function removes contradicting arguments, which define output format for floating point
+        and integer data values, improving compatibility with EPICS caget.
+
+    EPICS caget allows multiple contradicting format specifications and discards
+        all except the last one according to the order in which they are specified.
+        For example, for a floating point pv with the value 56.3452093 the
+        following format will be applied depending on the sequence of arguments:
+
+        ARGUMENTS                DISPLAYED VALUE
+
+        -e5 -lx -f5              56.34521
+        -f5 -lx -e5              5.63452e+01
+        -f5 -e5 -lx              0x38
+
+    This function clears data in 'parsed_args' for all arguments from the same format group except
+    the last in sequence as the arguments appear in command line. Since format arguments
+    for floating point and integer data belong to separate group of parameters, processing
+    is performed separately for floats and ints.
+
+    args - class that contains data extracted from command line arguments (returned by parser.parseargs())
+    Function changes fields of 'args' and returns no value.
+
+    Note: this function is a patch, which necessary because equivalent functionality is not available
+    from 'argparse' module.
+    '''
+
+    # Arguments from group 1 (floating point)
+    double_args = ["-e", "-f", "-g", "-s", "-lx", "-lo", "-lb"]
+    double_attrs = ["float_e", "float_f", "float_g", "float_s", "float_lx", "float_lo", "float_lb"]
+
+    _clean_args_for_group(args, double_args, double_attrs)
+
+    # Arguments from group 2 (floating point)
+    int_args = ["-0x", "-0o", "-0b"]
+    int_attrs = ["int_0x", "int_0o", "int_0b"]
+
+    _clean_args_for_group(args, int_args, int_attrs)
+
+
+def gen_data_format(args=None, data=None):
+    '''
+    Generates format specification for printing 'response.data' field
+
+      args - class that contains data on cmd line arguments (returned by parser.parseargs())
+      data - iterable object (typically numpy.narray), which contains data entries returned
+                by the server
+
+      Returns the instance of DataFormat class. Format is set to empty string if the function
+          is unable to select correct format.
+    '''
+
+    df = _DataPrintFormat()
+
+    # Both arguments 'arg' and 'data' are needed to produce meaningful result
+    if args is None or data is None or len(data) == 0:
+        return df
+
+    # If no format was specified, the default is "g" (as in EPICS caget)
+    df.format = "g"
+
+    # 'data' contains a list (or array) of strings
+    if(isinstance(data[0], str) or isinstance(data[0], bytes)):
+        df.format = "s"
+
+    # 'data' contains an array of floats
+    if(isinstance(data[0], float)):
+        # Check if any of the format specification arguments were passed
+        if args.float_e is not None:
+            df.format = ".{}e".format(args.float_e)
+        elif args.float_f is not None:
+            df.format = ".{}f".format(args.float_f)
+        elif args.float_g is not None:
+            df.format = ".{}g".format(args.float_g)
+        elif args.float_s:
+            # This feature is not implemented yet. Instead use floating point
+            #    value supplied by the server and print it in %f format.
+            #    This is still gives some elementary support for the argument -s.
+            df.format = "f"
+            df.float_server_precision = True
+        elif args.float_lx:  # Rounded hexadecimal
+            df.format = "X"
+            df.prefix = "0x"
+            df.float_round = True
+        elif args.float_lo:  # Rounded octal
+            df.format = "o"
+            df.prefix = "0o"
+            df.float_round = True
+        elif args.float_lb:  # Rounded binary
+            df.format = "b"
+            df.prefix = "0b"
+            df.float_round = True
+
+    # 'data' contains an array of integers
+    if(isinstance(data[0], numbers.Integral)):
+        if args.int_0x:
+            df.format = "X"   # Hexadecimal
+            df.prefix = "0x"
+        elif args.int_0o:
+            df.format = "o"   # Octal
+            df.prefix = "0o"
+        elif args.int_0b:
+            df.format = "b"   # Binary
+            df.prefix = "0b"
+
+    # Separator: may be a single character (quoted or not quoted) or quoted multiple characters
+    #          including spaces. EPICS caget allows only single character separators.
+    #          Quoted separator also may be an empty string (no separator), but this is
+    #          a meaningless feature.
+    if args.F is not None:
+        df.separator = args.F
+
+    return df
+
+
+def format_str_adjust(format_str=None, data_fmt=None):
+    '''
+    Performs the following changes to the format string 'format_str':
+        1. Replaces all occurrances of '{response.data}' with '{response_data}'
+        2. Inserts separator between fields if a separator is specified
+    '''
+
+    if format_str is None:
+        return None
+
+    if data_fmt is None:
+        data_fmt = _DataPrintFormat()  # No separator will be inserted
+
+    # In 'format_str': replace all instances of '{response.data}' with '{response_data}'
+    p = re.compile("{response.data}")
+    format_str = p.sub("{response_data}", format_str)
+
+    # If a separator is specified (argument -F), then put the separators between each field
+    if data_fmt.separator is not None:
+        p = re.compile("} *{")
+        format_str = p.sub("}" + "{}".format(data_fmt.separator) + "{", format_str)
+
+    return format_str
+
+
+def print_response_data(data=None, data_fmt=None):
+    '''
+    Prints data contained in iterable object 'data' to a string according to format specifications 'data_fmt'
+    Returns a string containing printed data.
+    '''
+
+    if data_fmt is None:
+        data_fmt = _DataPrintFormat()
+
+    s = ""
+
+    # There must be at least some elements in 'data' array
+    if data is None or len(data) == 0:
+        # Used to display empty array received from the server
+        return "[]"
+
+    # Format does NOT NEED to be set for the function to print properly.
+    #    The default python printing format for the type is used then.
+
+    sep = " "  # Default
+    # Note, that the separator may be an empty string and it still overrides the default " "
+    if data_fmt.separator is not None:
+        sep = data_fmt.separator
+
+    # Strings (or arrays of strings) are returned in the form of lists
+    #    of type 'bytes'. They need to be converted to regular strings for printing.
+    if(isinstance(data[0], bytes)):
+        data = [v.decode() for v in data]
+    # Convert to strings by printing values using selected format and prefix (0x, 0o or 0b)
+    data_str = [("{}{:" + data_fmt.format + "}").format(data_fmt.prefix, v) for v in data]
+    s = sep.join(data_str)
+    if not data_fmt.no_brackets:
+        s = "[" + s + "]"
+
+    return s

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -16,7 +16,7 @@ import logging
 from .. import ChannelType, set_handler, field_types, __version__
 from ..sync.client import read
 from .._utils import ShowVersionAction
-from .cli_print_formats import (print_response_data, gen_data_format,
+from .cli_print_formats import (format_response_data, gen_data_format,
                                 clean_format_args, format_str_adjust)
 
 
@@ -187,7 +187,7 @@ def main():
 
             format_str = format_str_adjust(format_str=format_str, data_fmt=data_fmt)
 
-            response_data_str = print_response_data(data=response.data,
+            response_data_str = format_response_data(data=response.data,
                                                     data_fmt=data_fmt)
 
             tokens = dict(pv_name=pv_name, response=response, response_data=response_data_str)

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -188,7 +188,7 @@ def main():
             format_str = format_str_adjust(format_str=format_str, data_fmt=data_fmt)
 
             response_data_str = format_response_data(data=response.data,
-                                                    data_fmt=data_fmt)
+                                                     data_fmt=data_fmt)
 
             tokens = dict(pv_name=pv_name, response=response, response_data=response_data_str)
             if hasattr(response.metadata, 'timestamp'):

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -13,9 +13,199 @@ Python session, do not import this module; instead import caproto.sync.client.
 import argparse
 from datetime import datetime
 import logging
+import numbers
+import re
+import sys
 from .. import ChannelType, set_handler, field_types, __version__
 from ..sync.client import read
 from .._utils import ShowVersionAction
+
+
+class _DataFormat:
+
+    def __init__(self):
+        self.format = ""
+        self.prefix = ""
+        self.separator = None 
+        self.float_round = False  # floating point data value
+                                    #    must be rounded to the nearest integer (long)
+        self.float_server_precision = False # The floating point data value must be requested 
+                                        #   from the server as string
+        self.no_brackets = False       # Print data as scalar (no brackets)
+
+    def is_set(self):
+        ''' Returns True if format string is not empty '''
+        return len(self.format)>0
+
+
+def _clean_format_args(args = None):
+    '''
+    The function removes contradicting arguments, which define output format for floating point
+        and integer data values, improving compatibility with EPICS caget.
+
+    EPICS caget allows multiple contradicting format specifications and discards
+        all except the last one according to command line order.
+        For example, for a floating point pv with the value 56.3452093 the
+        following format will be displayed depending on argument sequence:
+
+        ARGUMENTS                DISPLAYED VALUE
+
+        -e5 -lx -f5              56.34521
+        -f5 -lx -e5              5.63452e+01
+        -f5 -e5 -lx              0x38
+
+    This function clears data in 'args' for all arguments from the same format group except 
+    the last. Since format arguments for floating point and integer data belong to 
+    separate group of parameters, processing is performed separately for floats and ints.
+
+    args - class that contains data extracted from command line arguments (returned by parser.parseargs())
+    Function changes fields of 'args' and returns no value.
+    '''
+
+    double_fmt = ["e", "f", "g", "s", "lx", "lo", "lb"]
+    int_fmt = ["0x", "0o", "0b"]
+
+    def _find_last_arg(list_args = []):
+        sa = sys.argv
+        fm_selected = None
+        for ag in reversed(sa):
+            for fm in list_args:
+                p = re.compile("^-{}.*".format(fm))
+                if p.match(ag) is not None:
+                    fm_selected = fm
+                    break
+            if fm_selected is not None:
+                break
+        return fm_selected
+
+    arg_float = _find_last_arg(list_args = double_fmt)
+    if arg_float is not None:
+        if arg_float != "e": args.float_e = None
+        if arg_float != "f": args.float_f = None
+        if arg_float != "g": args.float_g = None
+        if arg_float != "s": args.float_s = False
+        if arg_float != "lx": args.float_lx = False
+        if arg_float != "lo": args.float_lo = False
+        if arg_float != "lb": args.float_lb = False
+
+    arg_int = _find_last_arg(list_args = int_fmt)
+    if arg_int is not None:
+        if arg_int != "0x": args.int_0x = False
+        if arg_int != "0o": args.int_0o = False
+        if arg_int != "0b": args.int_Ob = False
+
+
+def _gen_data_format(args = None, data = None):
+    '''
+    Generates format specification for printing 'response.data' elements
+
+      args - class that contains data on cmd line arguments (returned by parser.parseargs())
+      data - iterable object (typically numpy.narray), which contains data entries returned
+                by the server 
+
+      Returns the instance of DataFormat class. Format is set to empty string if the function
+          is unable to select correct format.
+    '''
+
+    # Remove contradicting format arguments. This function may be simply removed from code
+    #        if the functionality is not desired.
+    _clean_format_args(args = args)
+
+    df = _DataFormat()
+
+    # Both arguments 'arg' and 'data' are needed to produce meaningful result
+    if args is None or data is None or len(data)==0:
+        return df
+
+    # If no format was specified, the default is "g" (as in EPICS caget)
+    df.format = "g" 
+
+    # 'data' contains a list (or array) of strings
+    if(isinstance(data[0], str) or isinstance(data[0], bytes)):
+        df.format = "s"
+
+    # 'data' contains an array of floats
+    if(isinstance(data[0], float)):
+        # Check if any of the format specification arguments were passed
+        if args.float_e is not None:
+            df.format = ".{}e".format(args.float_e)
+        elif args.float_f is not None:
+            df.format = ".{}f".format(args.float_f)
+        elif args.float_g is not None:
+            df.format = ".{}g".format(args.float_g)
+        elif args.float_s:
+            # This feature is not implemented yet. Instead use floating point
+            #    value supplied by the server and print it in %f format
+            df.format = "f"   
+            df.float_server_precision = True
+        elif args.float_lx:  # Rounded hexadecimal
+            df.format = "X"
+            df.prefix = "0x"
+            df.float_round = True
+        elif args.float_lo:  # Rounded octal
+            df.format = "o"
+            df.prefix = "0o"
+            df.float_round = True
+        elif args.float_lb:  # Rounded binary
+            df.format = "b" 
+            df.prefix = "0b" 
+            df.float_round = True
+
+    # 'data' contains an array of integers
+    if(isinstance(data[0], numbers.Integral)):
+        if args.int_0x:
+            df.format = "X"
+            df.prefix = "0x"
+        elif args.int_0o:
+            df.format = "o"
+            df.prefix = "0o"
+        elif args.int_0b:
+            df.format = "b"
+            df.prefix = "0b"
+
+    # Separator: may be a single character (quoted or not quoted) or quoted multiple characters
+    #          including spaces. EPICS caget allows only single character separators.
+    #          Quoted separator also may be an empty string (no separator)
+    if args.F is not None:
+        df.separator = args.F
+
+    return df
+
+def _print_response_data(data=None, data_fmt=None):
+    '''
+    Prints data contained in iterable 'data' according to format specifications 'data_fmt'
+    Returns a string containing printed data.
+    '''
+
+    if data_fmt is None: data_fmt = _DataFormat()
+
+    s = ""
+
+    # There must be at least some data
+    if data is None or len(data)==0:
+        return s
+
+    # Format does NOT NEED to be set for the function to print properly.
+    #    The default python printing format for the type is used then.
+
+    sep = " "
+    if data_fmt.separator is not None: sep = data_fmt.separator
+
+    if not data_fmt.no_brackets:
+        s += "["
+    add_sep = False
+    for v in data:
+        if(isinstance(v, bytes)): v = v.decode()  # Convert class 'bytes' to regular string for printing
+        if add_sep: s += sep
+        add_sep = True
+        # Round the value if needed
+        if data_fmt.float_round and isinstance(v, float):
+            v = int(round(v)) 
+        s += ("{0:}{1:"+data_fmt.format+"}").format(data_fmt.prefix, v)
+    if not data_fmt.no_brackets:
+        s += "]"
+
+    return s
 
 
 def main():
@@ -57,7 +247,10 @@ def main():
                                  "(implies -d 'time')"))
     # TODO caget/caput also include a 'srvr' column which seems to be `sid`. We
     # would need a pretty invasive refactor to access that from here.
-    parser.add_argument('-d', type=str, default=None, metavar="DATA_TYPE",
+    #
+    # Note: -d, -a and -t are mutually exclusive options in caget. Option -a (or --wide)
+    #   overwrites data_type in request, therefore data_type can not be specified as a parameter
+    fmt_group.add_argument('-d', type=str, default=None, metavar="DATA_TYPE",
                         help=("Request a class of data type (native, status, "
                               "time, graphic, control) or a specific type. "
                               "Accepts numeric "
@@ -77,6 +270,38 @@ def main():
     parser.add_argument('--version', '-V', action='show_version',
                         default=argparse.SUPPRESS,
                         help="Show caproto version and exit.")
+    
+    fmt_group_float = parser.add_argument_group(title="Floating point type format",
+        description=("Default: Use %g format. Ignored if --format or --terse is used"))
+    fmt_group_float.add_argument('-e', dest="float_e", type=int, metavar="<nr>", action="store", 
+        help=("Use %%e format with precision of <nr> digits"))
+    fmt_group_float.add_argument('-f', dest="float_f", type=int, metavar="<nr>", action="store", 
+        help=("Use %%f format with precision of <nr> digits"))
+    fmt_group_float.add_argument('-g', dest="float_g", type=int, metavar="<nr>", action="store", 
+        help=("Use %%g format with precision of <nr> digits"))
+    fmt_group_float.add_argument('-s', dest="float_s", action="store_true", 
+        help=("Get value as string (honors server-side precision"))
+    fmt_group_float.add_argument('-lx', dest="float_lx", action="store_true", 
+        help=("Round to long integer and print as hex number"))
+    fmt_group_float.add_argument('-lo', dest="float_lo", action="store_true", 
+        help=("Round to long integer and print as octal number"))
+    fmt_group_float.add_argument('-lb', dest="float_lb", action="store_true", 
+        help=("Round to long integer and print as binary number"))
+
+    fmt_group_int = parser.add_argument_group(title="Integer number format",
+        description="Default: Print as decimal number. Ignored if --format or --terse is used")
+    fmt_group_int.add_argument('-0x', dest="int_0x", action="store_true", 
+        help=("Print as hex number"))
+    fmt_group_int.add_argument('-0o', dest="int_0o", action="store_true", 
+        help=("Print as octal number"))
+    fmt_group_int.add_argument('-0b', dest="int_0b", action="store_true", 
+        help=("Print as octal number"))
+
+    fmt_group_sep = parser.add_argument_group(title="Alternate output field separator",
+        description="Ignored if --format or --terse is used")
+    fmt_group_sep.add_argument('-F', type=str, metavar="<ofs>", action="store", 
+        help=("Use <ofs> as an alternate output field separator"))
+                            
     args = parser.parse_args()
     if args.no_color:
         set_handler(color=False)
@@ -92,6 +317,9 @@ def main():
         data_type = int(data_type)  # '0' -> 0
     except (ValueError, TypeError):
         if isinstance(data_type, str):
+            # Ignore DBR_ (or dbr_) prefix in data_type
+            if len(data_type) >= 4 and data_type.lower()[0:4] == "dbr_":
+                data_type = data_type[4:] 
             if data_type.lower() not in field_types:
                 # 'STRING' -> ChannelType.STRING
                 data_type = ChannelType[data_type.upper()]
@@ -100,30 +328,53 @@ def main():
         data_type = 'time'
     try:
         for pv_name in args.pv_names:
+
+            data_print_no_brackets = False # In some modes, the values must be printed as scalars,
+                                           #   without brackets
+
             response = read(pv_name=pv_name,
                             data_type=data_type,
                             timeout=args.timeout,
                             priority=args.priority,
                             force_int_enums=args.n,
                             repeater=not args.no_repeater)
+
+            data_fmt = _gen_data_format(args=args, data=response.data)
+
             if args.format is None:
-                format_str = '{pv_name: <40}  {response.data}'
+                if args.F is None:
+                    format_str = '{pv_name: <40}  {response.data}'
+                else:
+                    format_str = '{pv_name}  {response.data}'
             else:
                 format_str = args.format
+
             if args.terse:
+                format_str = '{response.data}'
                 if len(response.data) == 1:
-                    format_str = '{response.data[0]}'
-                else:
-                    format_str = '{response.data}'
+                    # Only single entries are printed as scalars (without brackets)
+                    data_fmt.no_brackets = True
+
             elif args.wide:
                 # TODO Make this look more like caget -a
                 format_str = '{pv_name} {timestamp} {response.data} {response.status.name}'
-            tokens = dict(pv_name=pv_name, response=response)
+
+            # In 'format_str': replace all instances of '{response.data}' with '{response_data}'
+            p = re.compile("{response.data}")
+            format_str = p.sub("{response_data}", format_str)
+            # If separator is specified, then put the separators between each field
+            if data_fmt.separator is not None:
+                p = re.compile("} *{")
+                format_str = p.sub("}"+"{}".format(data_fmt.separator)+"{", format_str)
+
+            response_data_str =_print_response_data(data=response.data, data_fmt=data_fmt)
+
+            tokens = dict(pv_name=pv_name, response=response, response_data=response_data_str)
             if hasattr(response.metadata, 'timestamp'):
                 dt = datetime.fromtimestamp(response.metadata.timestamp)
                 tokens['timestamp'] = dt
             print(format_str.format(**tokens))
-
+            
     except BaseException as exc:
         if args.verbose:
             # Show the full traceback.
@@ -160,6 +411,9 @@ class _ListTypesAction(argparse.Action):
         print()
         for elem in ChannelType:
             print(f'{elem.value: <2} {elem.name}')
+        print()
+        print("Type name may be preceded by 'DBR_' for compatiblity with EPICS caget utility")
+        print("   (ex. DBR_STRING is equivalent to STRING)")
         parser.exit()
 
 

--- a/caproto/commandline/get.py
+++ b/caproto/commandline/get.py
@@ -26,19 +26,19 @@ class _DataFormat:
     def __init__(self):
         self.format = ""
         self.prefix = ""
-        self.separator = None 
-        self.float_round = False  # floating point data value
-                                    #    must be rounded to the nearest integer (long)
-        self.float_server_precision = False # The floating point data value must be requested 
-                                        #   from the server as string
-        self.no_brackets = False       # Print data as scalar (no brackets)
+        self.separator = None
+        self.float_round = False    # floating point data value
+        #                             must be rounded to the nearest integer (long)
+        self.float_server_precision = False  # The floating point data value must be requested
+        #                                      from the server as string
+        self.no_brackets = False             # Print data as scalar (no brackets)
 
     def is_set(self):
         ''' Returns True if format string is not empty '''
-        return len(self.format)>0
+        return len(self.format) > 0
 
 
-def _clean_format_args(args = None):
+def _clean_format_args(args=None):
     '''
     The function removes contradicting arguments, which define output format for floating point
         and integer data values, improving compatibility with EPICS caget.
@@ -54,9 +54,9 @@ def _clean_format_args(args = None):
         -f5 -lx -e5              5.63452e+01
         -f5 -e5 -lx              0x38
 
-    This function clears data in 'args' for all arguments from the same format group except 
-    the last in sequence as the arguments appear in command line. Since format arguments 
-    for floating point and integer data belong to separate group of parameters, processing 
+    This function clears data in 'args' for all arguments from the same format group except
+    the last in sequence as the arguments appear in command line. Since format arguments
+    for floating point and integer data belong to separate group of parameters, processing
     is performed separately for floats and ints.
 
     args - class that contains data extracted from command line arguments (returned by parser.parseargs())
@@ -69,7 +69,7 @@ def _clean_format_args(args = None):
     double_fmt = ["e", "f", "g", "s", "lx", "lo", "lb"]
     int_fmt = ["0x", "0o", "0b"]
 
-    def _find_last_arg(list_args = []):
+    def _find_last_arg(list_args=[]):
         sa = sys.argv
         fm_selected = None
         for ag in reversed(sa):
@@ -82,30 +82,40 @@ def _clean_format_args(args = None):
                 break
         return fm_selected
 
-    arg_float = _find_last_arg(list_args = double_fmt)
+    arg_float = _find_last_arg(list_args=double_fmt)
     if arg_float is not None:
-        if arg_float != "e": args.float_e = None
-        if arg_float != "f": args.float_f = None
-        if arg_float != "g": args.float_g = None
-        if arg_float != "s": args.float_s = False
-        if arg_float != "lx": args.float_lx = False
-        if arg_float != "lo": args.float_lo = False
-        if arg_float != "lb": args.float_lb = False
+        if arg_float != "e":
+            args.float_e = None
+        if arg_float != "f":
+            args.float_f = None
+        if arg_float != "g":
+            args.float_g = None
+        if arg_float != "s":
+            args.float_s = False
+        if arg_float != "lx":
+            args.float_lx = False
+        if arg_float != "lo":
+            args.float_lo = False
+        if arg_float != "lb":
+            args.float_lb = False
 
-    arg_int = _find_last_arg(list_args = int_fmt)
+    arg_int = _find_last_arg(list_args=int_fmt)
     if arg_int is not None:
-        if arg_int != "0x": args.int_0x = False
-        if arg_int != "0o": args.int_0o = False
-        if arg_int != "0b": args.int_Ob = False
+        if arg_int != "0x":
+            args.int_0x = False
+        if arg_int != "0o":
+            args.int_0o = False
+        if arg_int != "0b":
+            args.int_Ob = False
 
 
-def _gen_data_format(args = None, data = None):
+def _gen_data_format(args=None, data=None):
     '''
     Generates format specification for printing 'response.data' field
 
       args - class that contains data on cmd line arguments (returned by parser.parseargs())
       data - iterable object (typically numpy.narray), which contains data entries returned
-                by the server 
+                by the server
 
       Returns the instance of DataFormat class. Format is set to empty string if the function
           is unable to select correct format.
@@ -113,16 +123,16 @@ def _gen_data_format(args = None, data = None):
 
     # Remove contradicting format arguments. This function may be simply removed from code
     #        if the functionality is not desired.
-    _clean_format_args(args = args)
+    _clean_format_args(args=args)
 
     df = _DataFormat()
 
     # Both arguments 'arg' and 'data' are needed to produce meaningful result
-    if args is None or data is None or len(data)==0:
+    if args is None or data is None or len(data) == 0:
         return df
 
     # If no format was specified, the default is "g" (as in EPICS caget)
-    df.format = "g" 
+    df.format = "g"
 
     # 'data' contains a list (or array) of strings
     if(isinstance(data[0], str) or isinstance(data[0], bytes)):
@@ -141,7 +151,7 @@ def _gen_data_format(args = None, data = None):
             # This feature is not implemented yet. Instead use floating point
             #    value supplied by the server and print it in %f format.
             #    This is still gives some elementary support for the argument -s.
-            df.format = "f"   
+            df.format = "f"
             df.float_server_precision = True
         elif args.float_lx:  # Rounded hexadecimal
             df.format = "X"
@@ -152,8 +162,8 @@ def _gen_data_format(args = None, data = None):
             df.prefix = "0o"
             df.float_round = True
         elif args.float_lb:  # Rounded binary
-            df.format = "b" 
-            df.prefix = "0b" 
+            df.format = "b"
+            df.prefix = "0b"
             df.float_round = True
 
     # 'data' contains an array of integers
@@ -177,27 +187,30 @@ def _gen_data_format(args = None, data = None):
 
     return df
 
+
 def _print_response_data(data=None, data_fmt=None):
     '''
     Prints data contained in iterable 'data' to a string according to format specifications 'data_fmt'
     Returns a string containing printed data.
     '''
 
-    if data_fmt is None: data_fmt = _DataFormat()
+    if data_fmt is None:
+        data_fmt = _DataFormat()
 
     s = ""
 
     # There must be at least some elements in 'data' array
-    if data is None or len(data)==0:
+    if data is None or len(data) == 0:
         # Used to display empty array received from the server
         return "[]"
 
     # Format does NOT NEED to be set for the function to print properly.
     #    The default python printing format for the type is used then.
 
-    sep = " " # Default
+    sep = " "  # Default
     # Note, that the separator may be an empty string and it still overrides the default " "
-    if data_fmt.separator is not None: sep = data_fmt.separator
+    if data_fmt.separator is not None:
+        sep = data_fmt.separator
 
     if not data_fmt.no_brackets:
         s += "["
@@ -205,13 +218,15 @@ def _print_response_data(data=None, data_fmt=None):
     for v in data:
         # Strings (or arrays of strings) are returned by the server in the form of lists
         #    of type 'bytes'. They need to be converted to regular strings for printing.
-        if(isinstance(v, bytes)): v = v.decode()  
-        if add_sep: s += sep
+        if(isinstance(v, bytes)):
+            v = v.decode()
+        if add_sep:
+            s += sep
         add_sep = True
         # Round the value if needed (if floating point number needs to be converted to closest int)
         if data_fmt.float_round and isinstance(v, float):
-            v = int(round(v)) 
-        s += ("{0:}{1:"+data_fmt.format+"}").format(data_fmt.prefix, v)
+            v = int(round(v))
+        s += ("{0:}{1:" + data_fmt.format + "}").format(data_fmt.prefix, v)
     if not data_fmt.no_brackets:
         s += "]"
 
@@ -261,11 +276,11 @@ def main():
     # Note: -d, -a and -t are mutually exclusive options in caget. Option -a (or --wide)
     #   overwrites data_type in request, therefore data_type can not be specified as a parameter
     fmt_group.add_argument('-d', type=str, default=None, metavar="DATA_TYPE",
-                        help=("Request a class of data type (native, status, "
-                              "time, graphic, control) or a specific type. "
-                              "Accepts numeric "
-                              "code ('3') or case-insensitive string ('enum')"
-                              ". See --list-types."))
+                           help=("Request a class of data type (native, status, "
+                                 "time, graphic, control) or a specific type. "
+                                 "Accepts numeric "
+                                 "code ('3') or case-insensitive string ('enum')"
+                                 ". See --list-types."))
     parser.add_argument('--list-types', action='list_types',
                         default=argparse.SUPPRESS,
                         help="List allowed values for -d and exit.")
@@ -280,39 +295,51 @@ def main():
     parser.add_argument('--version', '-V', action='show_version',
                         default=argparse.SUPPRESS,
                         help="Show caproto version and exit.")
-    
-    fmt_group_float = parser.add_argument_group(title="Floating point type format",
+
+    fmt_group_float = parser.add_argument_group(
+        title="Floating point type format",
         description=("If --format is set, the following arguments change formatting of the "
-            "{response.data} field if floating point value is displayed. The default format is %g."))
-    fmt_group_float.add_argument('-e', dest="float_e", type=int, metavar="<nr>", action="store", 
+                     "{response.data} field if floating point value is displayed. "
+                     "The default format is %g."))
+    fmt_group_float.add_argument(
+        '-e', dest="float_e", type=int, metavar="<nr>", action="store",
         help=("Use %%e format with precision of <nr> digits (e.g. -e5 or -e 5)"))
-    fmt_group_float.add_argument('-f', dest="float_f", type=int, metavar="<nr>", action="store", 
+    fmt_group_float.add_argument(
+        '-f', dest="float_f", type=int, metavar="<nr>", action="store",
         help=("Use %%f format with precision of <nr> digits (e.g. -f5 or -f 5)"))
-    fmt_group_float.add_argument('-g', dest="float_g", type=int, metavar="<nr>", action="store", 
+    fmt_group_float.add_argument(
+        '-g', dest="float_g", type=int, metavar="<nr>", action="store",
         help=("Use %%g format with precision of <nr> digits (e.g. -g5 or -g 5)"))
-    fmt_group_float.add_argument('-s', dest="float_s", action="store_true", 
+    fmt_group_float.add_argument(
+        '-s', dest="float_s", action="store_true",
         help=("Get value as string (honors server-side precision"))
-    fmt_group_float.add_argument('-lx', dest="float_lx", action="store_true", 
+    fmt_group_float.add_argument(
+        '-lx', dest="float_lx", action="store_true",
         help=("Round to long integer and print as hex number"))
-    fmt_group_float.add_argument('-lo', dest="float_lo", action="store_true", 
+    fmt_group_float.add_argument(
+        '-lo', dest="float_lo", action="store_true",
         help=("Round to long integer and print as octal number"))
-    fmt_group_float.add_argument('-lb', dest="float_lb", action="store_true", 
+    fmt_group_float.add_argument(
+        '-lb', dest="float_lb", action="store_true",
         help=("Round to long integer and print as binary number"))
 
-    fmt_group_int = parser.add_argument_group(title="Integer number format",
+    fmt_group_int = parser.add_argument_group(
+        title="Integer number format",
         description="If --format is set, the following arguments change formatting of the "
-            "{response.data} field if integer value is displayed. Decimal number is displayed by default.")
-    fmt_group_int.add_argument('-0x', dest="int_0x", action="store_true", 
-        help=("Print as hex number"))
-    fmt_group_int.add_argument('-0o', dest="int_0o", action="store_true", 
-        help=("Print as octal number"))
-    fmt_group_int.add_argument('-0b', dest="int_0b", action="store_true", 
-        help=("Print as binary number"))
+                    "{response.data} field if integer value is displayed. "
+                    "Decimal number is displayed by default.")
+    fmt_group_int.add_argument('-0x', dest="int_0x", action="store_true",
+                               help=("Print as hex number"))
+    fmt_group_int.add_argument('-0o', dest="int_0o", action="store_true",
+                               help=("Print as octal number"))
+    fmt_group_int.add_argument('-0b', dest="int_0b", action="store_true",
+                               help=("Print as binary number"))
 
     fmt_group_sep = parser.add_argument_group(title="Custom output field separator")
-    fmt_group_sep.add_argument('-F', type=str, metavar="<ofs>", action="store", 
+    fmt_group_sep.add_argument(
+        '-F', type=str, metavar="<ofs>", action="store",
         help=("Use <ofs> as an alternate output field separator (e.g. -F*, -F'*', -F '*', -F ' ** ')"))
-                            
+
     args = parser.parse_args()
     if args.no_color:
         set_handler(color=False)
@@ -330,7 +357,7 @@ def main():
         if isinstance(data_type, str):
             # Ignore DBR_ (or dbr_) prefix in data_type
             if len(data_type) >= 4 and data_type.lower()[0:4] == "dbr_":
-                data_type = data_type[4:] 
+                data_type = data_type[4:]
             if data_type.lower() not in field_types:
                 # 'STRING' -> ChannelType.STRING
                 data_type = ChannelType[data_type.upper()]
@@ -339,9 +366,6 @@ def main():
         data_type = 'time'
     try:
         for pv_name in args.pv_names:
-
-            data_print_no_brackets = False # In some modes, the values must be printed as scalars,
-                                           #   without brackets
 
             response = read(pv_name=pv_name,
                             data_type=data_type,
@@ -376,16 +400,16 @@ def main():
             # If a separator is specified (argument -F), then put the separators between each field
             if data_fmt.separator is not None:
                 p = re.compile("} *{")
-                format_str = p.sub("}"+"{}".format(data_fmt.separator)+"{", format_str)
+                format_str = p.sub("}" + "{}".format(data_fmt.separator) + "{", format_str)
 
-            response_data_str =_print_response_data(data=response.data, data_fmt=data_fmt)
+            response_data_str = _print_response_data(data=response.data, data_fmt=data_fmt)
 
             tokens = dict(pv_name=pv_name, response=response, response_data=response_data_str)
             if hasattr(response.metadata, 'timestamp'):
                 dt = datetime.fromtimestamp(response.metadata.timestamp)
                 tokens['timestamp'] = dt
             print(format_str.format(**tokens))
-            
+
     except BaseException as exc:
         if args.verbose:
             # Show the full traceback.

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -18,7 +18,7 @@ import time
 from ..sync.client import subscribe, block
 from .. import SubscriptionType, set_handler, __version__
 from .._utils import ShowVersionAction
-from .cli_print_formats import (print_response_data, gen_data_format,
+from .cli_print_formats import (format_response_data, gen_data_format,
                                 clean_format_args, format_str_adjust)
 
 
@@ -155,7 +155,7 @@ def main():
 
         format_str = format_str_adjust(format_str=format_str, data_fmt=data_fmt)
 
-        response_data_str = print_response_data(data=response.data,
+        response_data_str = format_response_data(data=response.data,
                                                 data_fmt=data_fmt)
 
         tokens['pv_name'] = pv_name

--- a/caproto/commandline/monitor.py
+++ b/caproto/commandline/monitor.py
@@ -156,7 +156,7 @@ def main():
         format_str = format_str_adjust(format_str=format_str, data_fmt=data_fmt)
 
         response_data_str = format_response_data(data=response.data,
-                                                data_fmt=data_fmt)
+                                                 data_fmt=data_fmt)
 
         tokens['pv_name'] = pv_name
         tokens['response'] = response

--- a/caproto/tests/test_cli_scripts.py
+++ b/caproto/tests/test_cli_scripts.py
@@ -127,13 +127,13 @@ fmt3 = '{response.data}'
                           ('caproto-get', ('float', '-lx')),
                           ('caproto-get', ('float', '-lo')),
                           ('caproto-get', ('float', '-lb')),
-                          # All at once (the last one is used)
+                          # All at once (the last one is used for output formatting)
                           ('caproto-get', ('float', '-e5', '-f5', '-g5', '-s', '-lx', '-lo', '-lb')),
                           #    integer -0x -0o -0b
                           ('caproto-get', ('int', '-0x')),
                           ('caproto-get', ('int', '-0o')),
                           ('caproto-get', ('int', '-0b')),
-                          # All at once (the last one is used)
+                          # All at once (the last one is used for output formatting)
                           ('caproto-get', ('int', '-0x', '-0o', '-0b')),
                           # Test separator (single character)
                           ('caproto-get', ('float', '-F-')),

--- a/caproto/tests/test_cli_scripts.py
+++ b/caproto/tests/test_cli_scripts.py
@@ -115,7 +115,7 @@ fmt3 = '{response.data}'
                           ('caproto-put', ('float', '3.16', '-l')),
                           ('caproto-put', ('float', '3.16', '-v')),
                           ('caproto-put', ('float', '3.16', '-vvv')),
-                          # Tests for output formatting arguments: 
+                          # Tests for output formatting arguments:
                           #    floating point -e -f -g -s -lx -lo -lb
                           ('caproto-get', ('float', '-e5')),
                           ('caproto-get', ('float', '-e', '5')),

--- a/caproto/tests/test_cli_scripts.py
+++ b/caproto/tests/test_cli_scripts.py
@@ -167,6 +167,34 @@ def test_cli(command, args, ioc, ):
                           ('float', '-p', '0'),
                           ('float', '-p', '99'),
                           ('float', '-w', '2'),
+                          # Tests for output formatting arguments:
+                          #    floating point -e -f -g -s -lx -lo -lb
+                          ('float', '-e5'),
+                          ('float', '-e', '5'),
+                          ('float', '-f5'),
+                          ('float', '-f', '5'),
+                          ('float', '-g5'),
+                          ('float', '-g', '5'),
+                          ('float', '-s'),
+                          ('float', '-lx'),
+                          ('float', '-lo'),
+                          ('float', '-lb'),
+                          # All at once (the last one is used for output formatting)
+                          ('float', '-e5', '-f5', '-g5', '-s', '-lx', '-lo', '-lb'),
+                          #    integer -0x -0o -0b
+                          ('int', '-0x'),
+                          ('int', '-0o'),
+                          ('int', '-0b'),
+                          # All at once (the last one is used for output formatting)
+                          ('int', '-0x', '-0o', '-0b'),
+                          # Test separator (single character)
+                          ('float', '-F-'),
+                          ('float', "-F'-'"),
+                          ('float', '-F', '-'),
+                          ('float', '-F', "'='"),
+                          ('waveform', '-F', "'-'"),
+                          # Test separator (multiple characters, not supported by EPICS monitor)
+                          ('float', '-F', "' = '"),
                           ])
 def test_monitor(args, ioc):
     args = fix_arg_prefixes(ioc, args)


### PR DESCRIPTION
The proposed feature implements support for CLI arguments specifying output formatting for `caproto-get`:

- **floating point formats**: `-e -f -g -s -lx -lo -lb` 
- **integer numbers**: `-0x -0o -0b`

The arguments change output formatting whenever floating point or integer values are printed to `stdout`. If a format string is specified in the argument list (e.g. `--format="{pv_name} {response.data}"`), the changed formatting is applied to the field `{response.data}`. If the field specification differs (e.g. `{response.data[0]}`) then the default format or format supplied within `--format` string is used. For example, the argument sequence `-0b --format="{response.data[0]:X}"` will print integer as hex number, despite `-0b` argument that selects binary format. The formatting also works in `--wide` and `-terse` modes.   

EPICS caget accepts contradicting output formatting arguments and sets the format according to the last specified argument from the same group. Similar behavior is built into the proposed implementation. Parameters for float and int formats belong to different groups and are processed separately. For example, invocation of `caproto-get` (`simple.py` ioc):
```
caproto-get -f5 -0x -lx -0b simple:A simple:B
```
results in pv `simple:A` (int) to be printed in binary format and pv `simple:B` (float) to be rounded to the nearest int and printed in hex format.

**Custom separator**: `-F`. Sets custom separator for built-in or supplied format. The separator is inserted between fields and between array elements. Examples that set separator to `*` (consistent with the behavior of EPICS caget): `-F*`, `-F *`, `-F'*'`,`-F '*'`. EPICS caget accepts parameter -F without any value and sets separator to 's'. Such behavior is difficult to implement ('argparse' doesn't allow optional value), but it seems useless anyway. Also, EPICS caget accepts only single character separators, but the proposed implementation allows setting separator to a string of arbitrary length.
For example
``` 
caproto-get --a -F ' ** ' -e5 -0x simple:A simple:B simple:C
```
prints the pvs using standard `--wide` format string, setting separator between fields and elements of the array `simple:C` to `' ** '`. The floating point value of `simple:B` is printed in scientific format and int values of `simple:A` and `simple:B` are printed in hex format. 

The separator will also be inserted between fields if the format string is supplied with `--format` argument in case the format contains only spaces between the fields. For example if format string is specified as
```
-F ' ** ' --format="{pv_value}      {response.data[0]:X}" 
```
the separator will be inserted between two fields. If the definition is changed to
```
-F ' ** ' --format="{pv_value}      0x{response.data[0]:X}" 
```
by adding prefix `0x` before the second field, the separator will not be inserted. Note, that all spaces between `}` and `{` are replaced by the single separator: in the above example `}       {` is replaced by `} ** {`.

Added **support for standard EPICS type names** that start with `DBR_` (or `dbr_`). In EPICS `DBR_` prefix is optional and may be omitted. In the proposed implementation, if type name starts with `DBR_` (not case sensitive), the prefix is removed from the string before it is used for generating request. This feature improves compatibility with EPICS caget.

The **tests** were added for the proposed features. Unfortunately, the tests are basic and verify the exit codes returned by program in response to the sets of arguments, but not the formatting itself.