### PR TITLE
FIX: Client should use broadcast addresses.

### DIFF
--- a/caproto/_utils.py
+++ b/caproto/_utils.py
@@ -273,7 +273,10 @@ def get_address_list():
     addr_list = env['EPICS_CA_ADDR_LIST']
 
     if not addr_list or auto_addr_list.lower() == 'yes':
-        return ['255.255.255.255']
+        if netifaces is not None:
+            return [bcast for addr, bcast in get_netifaces_addresses()]
+        else:
+            return ['255.255.255.255']
 
     return addr_list.split(' ')
 

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -5,7 +5,7 @@ from caproto._headers import MessageHeader
 
 
 def test_broadcast_auto_address_list():
-    netifaces = pytest.importorskip('netifaces')
+    pytest.importorskip('netifaces')
     env = os.environ.copy()
     try:
         os.environ['EPICS_CA_ADDR_LIST'] = ''

--- a/caproto/tests/test_utils.py
+++ b/caproto/tests/test_utils.py
@@ -5,11 +5,13 @@ from caproto._headers import MessageHeader
 
 
 def test_broadcast_auto_address_list():
+    netifaces = pytest.importorskip('netifaces')
     env = os.environ.copy()
     try:
         os.environ['EPICS_CA_ADDR_LIST'] = ''
         os.environ['EPICS_CA_AUTO_ADDR_LIST'] = 'YES'
-        assert ca.get_address_list() == ['255.255.255.255']
+        expected = [bcast for addr, bcast in ca.get_netifaces_addresses()]
+        assert ca.get_address_list() == expected
     finally:
         os.environ = env
 


### PR DESCRIPTION
Thanks to @mrakitin for perservering to get to the bottom of this and
thanks to ZY (not sure of his GitHub handle) for some assistance.

This _partially_ reverts #404. I believe the changes to the server in
#404 are correct but the changes to the client were not correct.
When `EPICS_CA_AUTO_ADDR_LIST='yes'`, clients should search on the
broadcast address of each interface rather than only
`['255.255.255.255]`.

See https://github.com/epics-base/epics-base/blob/d77a96d23d962f996f12e29255aa29beed64c1b1/modules/ca/src/client/iocinf.cpp#L223

@mrakitin will post a follow-up comment shortly showing that this
fix works in production.

This does raise a question for me about whether we should add
``netifaces`` as a required dependency for caproto (heresy!). Silently
falling back to `['255.255.255.255']` when `netifaces` is not installed
seems likely to trip up users. That's the approach we took before #404,
and I have reinstated it here, but I think a hard dependency on `netifaces`
---or else vendoring the part we need---may be a more proper approach.